### PR TITLE
Feature/safer queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,10 +94,11 @@ Any contributions are welcome, be it pull requests, code reviews, documentation 
 If you decide to contribute through code, please run the tests after you change the code:
 
 ```shell
-$ docker-compose run tests        # run all tests
-$ docker-compose run testpostgres # run only PostgreSQL tests
-$ nimble test                     # run all tests natively; requires a running PostgreSQL server!
-$ nim c -r tests/testsqlite.nim   # run a single test suite
+$ docker-compose run tests                        # run all tests in Docker
+$ docker-compose run test tests/testpostgres.nim  # run a single test suite in Docker
+$ nimble test                                     # run all tests natively;
+                                                  # requires a running PostgreSQL server!
+$ nim c -r tests/testsqlite.nim                   # run a single test suite natively
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -24,31 +24,34 @@ $ nimble install norm
 ## Quickstart
 
 ```nim
-import norm / sqlite              # Import SQLite backend. Another option is ``norm / postgres``.
-import logging                    # Import logging to inspect the generated SQL statements.
+import norm / sqlite                      # Import SQLite backend.
+# import norm / postgres                  # Import PostgreSQL backend.
+import logging                            # Import logging to inspect the generated SQL statements.
 import unicode, sugar
 
-db("petshop.db", "", "", ""):     # Set DB connection credentials.
-  type                            # Describe object model in an ordinary type section.
+db("petshop.db", "", "", ""):             # Set DB connection credentials.
+  type                                    # Describe object model in an ordinary type section.
     User = object
-      age: int                    # Nim types are automatically converted into SQL types and back.
-                                  # You can specify how types are converted using ``parser``,
-                                  # ``formatter``, ``parseIt``, and ``formatIt`` pragmas.
+      age: int                            # Nim types are automatically converted into SQL types
+                                          # and back.
+                                          # You can specify how types are converted using
+                                          # ``parser``, ``formatter``, ``parseIt``,
+                                          # and ``formatIt`` pragmas.
       name {.
-        formatIt: capitalize(it)  # Guarantee that ``name`` is stored in DB capitalized.
+        formatIt: capitalize(it)          # Enforce that ``name`` is stored in DB capitalized.
       .}: string
 
 addHandler newConsoleLogger()
 
-withDb:                           # Start a DB session.
-  createTables(force=true)        # Create tables for all objects. Drop tables if they exist.
+withDb:                                   # Start a DB session.
+  createTables(force=true)                # Create tables for objects. Drop tables if they exist.
 
-  var bob = User(                 # Create a ``User`` instance as you normally would.
-    name: "bob",                  # Note that the instance is mutable. This is mandatory!
+  var bob = User(                         # Create a ``User`` instance as you normally would.
+    name: "bob",                          # Note that the instance is mutable. This is mandatory!
     age: 23
   )
-  bob.insert()                    # Insert ``bob`` into DB.
-  dump bob.id                     # ``id`` attr is added by Norm and updated on insertion.
+  bob.insert()                            # Insert ``bob`` into DB.
+  dump bob.id                             # ``id`` attr is added by Norm and updated on insertion.
 
   var bobby = User(name: "bobby", age: 34)
   bobby.insert()
@@ -57,24 +60,23 @@ withDb:                           # Start a DB session.
   alice.insert()
 
 withDb:
-  let bobs = User.getMany(        # Read records from DB:
-    100,                          # - only the first 100 records
-    where="name LIKE 'Bob%'",     # - find by condition
-    orderBy="age DESC"            # - order by age from oldest to youngest
+  let bobs = User.getMany(                # Read records from DB:
+    100,                                  # - only the first 100 records
+    cond="name LIKE 'Bob%' ORDER BY age"  # - find by condition
   )
 
   dump bobs
 
 withDb:
-  var bob = User.getOne(1)        # Fetch record from DB and store it as ``User`` instance.
-  bob.age += 10                   # Change attr value.
-  bob.update()                    # Update the record in DB.
+  var bob = User.getOne(1)                # Fetch record from DB and store it as ``User`` instance.
+  bob.age += 10                           # Change attr value.
+  bob.update()                            # Update the record in DB.
 
-  bob.delete()                    # Delete the record.
-  dump bob.id                     # ``id`` is 0 for objects not stored in DB.
+  bob.delete()                            # Delete the record.
+  dump bob.id                             # ``id`` is 0 for objects not stored in DB.
 
 withDb:
-  dropTables()                    # Drop all tables.
+  dropTables()                            # Drop all tables.
 ```
 
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,57 +1,65 @@
 # Changelog
 
+-   ❗—backward incompatible API change
+-   ➕—new feature
+-   👌—bugfix
+-   🔨—refactoring
+-   ✅—test suite improvement
+
 ## 1.0.9 (in progress)
 
--   Add `getOne(where: string)` procs to get a single record by condition.
+-   ❗ Change signatures for `getMany` and `getOne`: instead of `where` and `orderBy` args there's a single `cond` arg.
+-   ➕ Add `params` arg to `getMany` and `getOne` to allow safe value insertion in SQL queries.
+-   ➕ Add ```getOne(cond: string, params: varargs[string, `$`])``` procs to query a single record by condition.
 
 ## 1.0.8
 
--   SQLite: Add `{.onUpdate}` and `{.onDelete.}` pragmas (thanks to @alaviss).
--   SQLite: Add support for multiple foreign keys (thanks to @alaviss).
--   SQLite: Enable foreign keys for all connections (thanks to @alaviss).
--   SQLite: Add `unique` pragma.
--   Add tests for multiple foreign keys.
+-   ➕ SQLite: Add `{.onUpdate}` and `{.onDelete.}` pragmas (thanks to @alaviss).
+-   ➕ SQLite: Add `unique` pragma.
+-   👌 SQLite: Add support for multiple foreign keys (thanks to @alaviss).
+-   👌 SQLite: Enable foreign keys for all connections (thanks to @alaviss).
+-   ✅ Add tests for multiple foreign keys.
 
 
 ## 1.0.7
 
--   Add ``orderBy`` argument to ``getMany`` procs.
+-   ➕ Add ``orderBy`` argument to ``getMany`` procs.
 
 
 ## 1.0.6
 
--   Log all generated SQL statements as debug level logs.
+-   ➕ Log all generated SQL statements as debug level logs.
 
 
 ## 1.0.5
 
--   Do not require ``chronicles`` package.
+-   ➕ Do not require ``chronicles`` package.
 
 
 ## 1.0.4
 
--   Add ``WHERE`` lookup to ``getMany`` procs.
+-   ➕ Add ``WHERE`` lookup to ``getMany`` procs.
 
 
 ## 1.0.3
 
--   Objutils: Rename ``[]`` field accessor to ``dot`` to avoid collisions with ``tables`` module.
+-   🔨 Objutils: Rename ``[]`` field accessor to ``dot`` to avoid collisions with ``tables`` module.
 
 
 ## 1.0.2
 
--   Procs defined in ``db`` macro are now passed as is to the resulting code and are not forced inside ``withDb`` template.
--   Allow to override column names for fields with ``dbCol`` pragma.
+-   ❗ Procs defined in ``db`` macro are now passed as is to the resulting code and are not forced inside ``withDb`` template.
+-   ➕ Allow to override column names for fields with ``dbCol`` pragma.
 
 
 ## 1.0.1
 
--   Respect custom field parsers and formatters.
--   Type conversion: Fix issue with incorrect conversion of field named ``name``.
--   Rowutils: Respect ``ro`` pragma in ``toRow`` proc.
--   Objutils: Respect ``ro`` pragma in ``fieldNames`` proc.
+-   ➕ Respect custom field parsers and formatters.
+-   ➕ Rowutils: Respect ``ro`` pragma in ``toRow`` proc.
+-   ➕ Objutils: Respect ``ro`` pragma in ``fieldNames`` proc.
+-   ✅ Type conversion: Fix issue with incorrect conversion of field named ``name``.
 
 
 ## 1.0.0
 
--   Initial release.
+-   🎉 Initial release.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,13 +9,13 @@ services:
     volumes:
       - .:/usr/src/app
     command: nimble test
-  testpostgres:
+  test:
     build: .
     depends_on:
       - db
     volumes:
       - .:/usr/src/app
-    command: nim c -r tests/testpostgres.nim
+    entrypoint: nim c -r
   docs:
     image: nimlang/nim
     volumes:

--- a/src/norm.nim
+++ b/src/norm.nim
@@ -15,31 +15,34 @@ Quickstart
 ==========
 
 .. code-block:: nim
-    import norm / sqlite              # Import SQLite backend. Another option is ``norm / postgres``.
-    import logging                    # Import logging to inspect the generated SQL statements.
+    import norm / sqlite                      # Import SQLite backend.
+    # import norm / postgres                  # Import PostgreSQL backend.
+    import logging                            # Import logging to inspect the generated SQL statements.
     import unicode, sugar
 
-    db("petshop.db", "", "", ""):     # Set DB connection credentials.
-      type                            # Describe object model in an ordinary type section.
+    db("petshop.db", "", "", ""):             # Set DB connection credentials.
+      type                                    # Describe object model in an ordinary type section.
         User = object
-          age: int                    # Nim types are automatically converted into SQL types and back.
-                                      # You can specify how types are converted using ``parser``,
-                                      # ``formatter``, ``parseIt``, and ``formatIt`` pragmas.
+          age: int                            # Nim types are automatically converted into SQL types
+                                              # and back.
+                                              # You can specify how types are converted using
+                                              # ``parser``, ``formatter``, ``parseIt``,
+                                              # and ``formatIt`` pragmas.
           name {.
-            formatIt: capitalize(it)  # Guarantee that ``name`` is stored in DB capitalized.
+            formatIt: capitalize(it)          # Enforce that ``name`` is stored in DB capitalized.
           .}: string
 
     addHandler newConsoleLogger()
 
-    withDb:                           # Start a DB session.
-      createTables(force=true)        # Create tables for all objects. Drop tables if they exist.
+    withDb:                                   # Start a DB session.
+      createTables(force=true)                # Create tables for objects. Drop tables if they exist.
 
-      var bob = User(                 # Create a ``User`` instance as you normally would.
-        name: "bob",                  # Note that the instance is mutable. This is mandatory!
+      var bob = User(                         # Create a ``User`` instance as you normally would.
+        name: "bob",                          # Note that the instance is mutable. This is mandatory!
         age: 23
       )
-      bob.insert()                    # Insert ``bob`` into DB.
-      dump bob.id                     # ``id`` attr is added by Norm and updated on insertion.
+      bob.insert()                            # Insert ``bob`` into DB.
+      dump bob.id                             # ``id`` attr is added by Norm and updated on insertion.
 
       var bobby = User(name: "bobby", age: 34)
       bobby.insert()
@@ -48,24 +51,23 @@ Quickstart
       alice.insert()
 
     withDb:
-      let bobs = User.getMany(        # Read records from DB:
-        100,                          # - only the first 100 records
-        where="name LIKE 'Bob%'",     # - find by condition
-        orderBy="age DESC"            # - order by age from oldest to youngest
+      let bobs = User.getMany(                # Read records from DB:
+        100,                                  # - only the first 100 records
+        cond="name LIKE 'Bob%' ORDER BY age"  # - find by condition
       )
 
       dump bobs
 
     withDb:
-      var bob = User.getOne(1)        # Fetch record from DB and store it as ``User`` instance.
-      bob.age += 10                   # Change attr value.
-      bob.update()                    # Update the record in DB.
+      var bob = User.getOne(1)                # Fetch record from DB and store it as ``User`` instance.
+      bob.age += 10                           # Change attr value.
+      bob.update()                            # Update the record in DB.
 
-      bob.delete()                    # Delete the record.
-      dump bob.id                     # ``id`` is 0 for objects not stored in DB.
+      bob.delete()                            # Delete the record.
+      dump bob.id                             # ``id`` is 0 for objects not stored in DB.
 
     withDb:
-      dropTables()                    # Drop all tables.
+      dropTables()                            # Drop all tables.
 ]##
 
 import norm / [rowutils, objutils]

--- a/src/norm/postgres.nim
+++ b/src/norm/postgres.nim
@@ -146,18 +146,17 @@ proc genInsertQuery*(obj: object, force: bool): SqlQuery =
   result = sql "INSERT INTO $# ($#) VALUES ($#)" % [type(obj).getTable(), fields.join(", "),
                                                     placeholders.join(", ")]
 
-proc genGetOneQuery*(obj: object, condition = "id = ?"): SqlQuery =
+proc genGetOneQuery*(obj: object, condition: string): SqlQuery =
   ## Generate ``SELECT`` query to fetch a single record for an object.
 
   sql "SELECT $# FROM $# WHERE $#" % [obj.getColumns(force=true).join(", "),
-                                          type(obj).getTable(), condition]
+                                      type(obj).getTable(), condition]
 
-proc genGetManyQuery*(obj: object, condition, orderBy: string): SqlQuery =
+proc genGetManyQuery*(obj: object, condition: string): SqlQuery =
   ## Generate ``SELECT`` query to fetch multiple records for an object.
 
-  sql "SELECT $# FROM $# WHERE $# ORDER BY $# LIMIT ? OFFSET ?" % [
-                                                      obj.getColumns(force=true).join(", "),
-                                                      type(obj).getTable(), condition, orderBy]
+  sql "SELECT $# FROM $# WHERE $# LIMIT ? OFFSET ?" % [obj.getColumns(force=true).join(", "),
+                                                       type(obj).getTable(), condition]
 
 proc getUpdateQuery*(obj: object, force: bool): SqlQuery =
   ## Generate ``UPDATE`` query for an object.
@@ -227,14 +226,40 @@ template genWithDb(connection, user, password, database: string,
 
         obj.id = dbConn.insertID(insertQuery, params).int
 
+      template getOne(obj: var object, cond: string, params: varargs[string, `$`]) {.used.} =
+        ##[ Read a record from DB by condition and store it into an existing object instance.
+
+        If multiple records are found, return the first one.
+        ]##
+
+        let getOneQuery = genGetOneQuery(obj, cond)
+
+        debug getOneQuery, " <- ", params.join(", ")
+
+        let row = dbConn.getRow(getOneQuery, params)
+
+        if row.isEmpty():
+          raise newException(KeyError, "Record by condition '$#' with params '$#' not found." %
+                             [cond, params.join(", ")])
+
+        row.to(obj)
+
+      proc getOne(T: type, cond: string, params: varargs[string, `$`]): T {.used.} =
+        ##[ Read a record from DB by condition into a new object instance.
+
+        If multiple records are found, return the first one.
+        ]##
+
+        result.getOne(cond, params)
+
       template getOne(obj: var object, id: int) {.used.} =
         ## Read a record from DB and store it into an existing object instance.
 
-        let getOneQuery = genGetOneQuery(obj)
+        let getOneQuery = genGetOneQuery(obj, "id=?")
 
         debug getOneQuery, " <- ", $id
 
-        let row = dbConn.getRow(genGetOneQuery(obj), id)
+        let row = dbConn.getRow(getOneQuery, id)
 
         if row.isEmpty():
           raise newException(KeyError, "Record with id=$# not found." % $id)
@@ -246,42 +271,18 @@ template genWithDb(connection, user, password, database: string,
 
         result.getOne(id)
 
-      template getOne(obj: var object, where: string) {.used.} =
-        ##[ Read a record from DB by condition and store it into an existing object instance.
+      proc getMany(objs: var seq[object], limit: int, offset = 0,
+                   cond = "TRUE", params: varargs[string, `$`]) {.used.} =
+        ##[ Read ``limit`` records with ``offset`` from DB into an existing open array of objects.
 
-        If multiple records are found, return the first one.
-        ]##
-
-        let getOneQuery = genGetOneQuery(obj, where)
-
-        debug getOneQuery
-
-        let row = dbConn.getRow(getOneQuery)
-
-        if row.isEmpty():
-          raise newException(KeyError, "Record by condition '$#' not found." % where)
-
-        row.to(obj)
-
-      proc getOne(T: type, where: string): T {.used.} =
-        ##[ Read a record from DB by condition into a new object instance.
-
-        If multiple records are found, return the first one.
-        ]##
-
-        result.getOne(where)
-
-      proc getMany(objs: var seq[object], limit: int, offset = 0, where = "TRUE", orderBy = "id") {.used.} =
-        ##[ Read ``limit`` records with ``offset``  from DB into an existing open array of objects.
-
-        Filter using ``where`` condition.
+        Filter using ``cond`` condition.
         ]##
 
         if len(objs) == 0: return
 
         let
-          getManyQuery = genGetManyQuery(objs[0], where, orderBy)
-          params = [$min(limit, len(objs)), $offset]
+          getManyQuery = genGetManyQuery(objs[0], cond)
+          params = @params & @[$min(limit, len(objs)), $offset]
 
         debug getManyQuery, " <- ", params.join(", ")
 
@@ -289,15 +290,16 @@ template genWithDb(connection, user, password, database: string,
 
         rows.to(objs)
 
-      proc getMany(T: type, limit: int, offset = 0, where = "TRUE", orderBy = "id"): seq[T] {.used.} =
+      proc getMany(T: type, limit: int, offset = 0,
+                   cond = "TRUE", params: varargs[string, `$`]): seq[T] {.used.} =
         ##[ Read ``limit`` records  with ``offset`` from DB into a sequence of objects,
         create the sequence on the fly.
 
-        Filter using ``where`` condition.
+        Filter using ``cond`` condition.
         ]##
 
         result.setLen limit
-        result.getMany(limit, offset, where, orderBy)
+        result.getMany(limit, offset, cond, params)
 
       template update(obj: object, force = false) {.used.} =
         ##[ Update DB record with object field values.

--- a/src/norm/sqlite.nim
+++ b/src/norm/sqlite.nim
@@ -233,7 +233,7 @@ template genWithDb(connection, user, password, database: string,
         let row = dbConn.getRow(getOneQuery, params)
 
         if row.isEmpty():
-          raise newException(KeyError, "Record by condition '$#' and params '$#' not found." %
+          raise newException(KeyError, "Record by condition '$#' with params '$#' not found." %
                              [cond, params.join(", ")])
 
         row.to(obj)

--- a/src/norm/sqlite.nim
+++ b/src/norm/sqlite.nim
@@ -267,9 +267,9 @@ template genWithDb(connection, user, password, database: string,
 
       proc getMany(objs: var seq[object], limit: int, offset = 0,
                    cond = "1", params: varargs[string, `$`]) {.used.} =
-        ##[ Read ``limit`` records with ``offset``  from DB into an existing open array of objects.
+        ##[ Read ``limit`` records with ``offset`` from DB into an existing open array of objects.
 
-        Filter using ``where`` condition.
+        Filter using ``cond`` condition.
         ]##
 
         if len(objs) == 0: return
@@ -289,7 +289,7 @@ template genWithDb(connection, user, password, database: string,
         ##[ Read ``limit`` records  with ``offset`` from DB into a sequence of objects,
         create the sequence on the fly.
 
-        Filter using ``where`` condition.
+        Filter using ``cond`` condition.
         ]##
 
         result.setLen limit

--- a/tests/testpostgres.nim
+++ b/tests/testpostgres.nim
@@ -143,16 +143,20 @@ suite "Creating and dropping tables, CRUD":
       check book.id == 8
       check edition.id == 8
 
-  test "Filter and sort records":
+  test "Query records":
     withDb:
-      let someBooks = Book.getMany(10, where="title IN ('Book 1', 'Book 5')", orderBy="title DESC")
+      let someBooks = Book.getMany(10, cond="title IN (?, ?) ORDER BY title DESC",
+                                   params=["Book 1", "Book 5"])
 
       check len(someBooks) == 2
       check someBooks[0].title == "Book 5"
       check someBooks[1].authorEmail == "test-1@example.com"
 
-      let someBook = Book.getOne "authoremail='test-2@example.com'"
+      let someBook = Book.getOne("authoremail=?", "test-2@example.com")
       check someBook.id == 2
+
+      expect KeyError:
+        let notExistingBook = Book.getOne("title=?", "Does not exist")
 
   test "Update records":
     withDb:

--- a/tests/testsqlite.nim
+++ b/tests/testsqlite.nim
@@ -167,8 +167,12 @@ suite "Creating and dropping tables, CRUD":
       check someBooks[0].title == "Book 5"
       check someBooks[1].authorEmail == "test-1@example.com"
 
-      let someBook = Book.getOne(cond="authorEmail=?", params=["test-2@example.com"])
+      let someBook = Book.getOne("authorEmail=?", "test-2@example.com")
       check someBook.id == 2
+      let notExistingBook = Book.getOne("title=?", "foo")
+
+      expect KeyError:
+        let notExistingBook = Book.getOne("title=?", "foo")
 
   test "Update records":
     withDb:

--- a/tests/testsqlite.nim
+++ b/tests/testsqlite.nim
@@ -169,7 +169,6 @@ suite "Creating and dropping tables, CRUD":
 
       let someBook = Book.getOne("authorEmail=?", "test-2@example.com")
       check someBook.id == 2
-      let notExistingBook = Book.getOne("title=?", "foo")
 
       expect KeyError:
         let notExistingBook = Book.getOne("title=?", "foo")

--- a/tests/testsqlite.nim
+++ b/tests/testsqlite.nim
@@ -160,13 +160,14 @@ suite "Creating and dropping tables, CRUD":
 
   test "Filter and sort records":
     withDb:
-      let someBooks = Book.getMany(10, where="title IN ('Book 1', 'Book 5')", orderBy="title DESC")
+      let someBooks = Book.getMany(10, cond="title IN (?, ?) ORDER BY title DESC",
+                                   params=["Book 1", "Book 5"])
 
       check len(someBooks) == 2
       check someBooks[0].title == "Book 5"
       check someBooks[1].authorEmail == "test-1@example.com"
 
-      let someBook = Book.getOne "authorEmail='test-2@example.com'"
+      let someBook = Book.getOne(cond="authorEmail=?", params=["test-2@example.com"])
       check someBook.id == 2
 
   test "Update records":

--- a/tests/testsqlite.nim
+++ b/tests/testsqlite.nim
@@ -158,7 +158,7 @@ suite "Creating and dropping tables, CRUD":
       check book.id == 8
       check edition.id == 8
 
-  test "Filter and sort records":
+  test "Query records":
     withDb:
       let someBooks = Book.getMany(10, cond="title IN (?, ?) ORDER BY title DESC",
                                    params=["Book 1", "Book 5"])
@@ -171,7 +171,7 @@ suite "Creating and dropping tables, CRUD":
       check someBook.id == 2
 
       expect KeyError:
-        let notExistingBook = Book.getOne("title=?", "foo")
+        let notExistingBook = Book.getOne("title=?", "Does not exist")
 
   test "Update records":
     withDb:


### PR DESCRIPTION
Attempt to offer a safer option to construct queries. As of Norm 1.0.8, `getMany` queries are plain strings. Any user-provided data is inserted as is or has to be prepared by your program.

With the changes in this PR, conditions for `getMany` and `getOne` procs can contain placeholders. The values for them are provided in a separate `params` argument.

The PR introduces backward incompatible changes. Instead of two args `where` and `orderBy` there's only one `cond`. If you need ordering, just put `ORDER BY` in your `cond`.

Fix https://github.com/moigagoo/norm/issues/4