### PR TITLE
Changed getMany's limit parameter to an optional parameter.

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,5 +113,4 @@ $ nim c -r tests/testsqlite.nim                   # run a single test suite nati
 
 ### ❤ Contributors ❤
 
-- [@moigagoo](https://github.com/moigagoo)
-- [@alaviss](https://github.com/alaviss)
+https://github.com/moigagoo/norm/graphs/contributors

--- a/src/norm/postgres.nim
+++ b/src/norm/postgres.nim
@@ -222,7 +222,7 @@ template genWithDb(connection, user, password, database: string, dbTypeNames: op
 
         result.getOne(id)
 
-      proc getMany(objs: var seq[object], limit: int = -1, offset = 0,
+      proc getMany(objs: var seq[object], limit: int, offset = 0,
                    cond = "TRUE", params: varargs[DbValue, dbValue]) {.used.} =
         ##[ Read ``limit`` records with ``offset`` from DB into an existing open array of objects.
 
@@ -232,21 +232,16 @@ template genWithDb(connection, user, password, database: string, dbTypeNames: op
         if len(objs) == 0: return
 
         let
-          withLimit = if limit < 0: false else: true
-          getManyQuery = genGetManyQuery(objs[0], cond, len(params), withLimit = withLimit)
-        var params = @params
-        if withLimit:
-          params.add(?min(limit, len(objs)))
-        params.add(?offset)
+          getManyQuery = genGetManyQuery(objs[0], cond, len(params))
+          params = @params & @[?min(limit, len(objs)), ?offset]
 
         debug getManyQuery, " <- ", params.join(", ")
-        let rows = dbConn.getAllRows(getManyQuery, params)
 
-        if limit < 0: objs.setLen len(rows)
+        let rows = dbConn.getAllRows(getManyQuery, params)
 
         rows.to(objs)
 
-      proc getMany(T: typedesc, limit: int = -1, offset = 0,
+      proc getMany(T: typedesc, limit: int, offset = 0,
                    cond = "TRUE", params: varargs[DbValue, dbValue]): seq[T] {.used.} =
         ##[ Read ``limit`` records  with ``offset`` from DB into a sequence of objects,
         create the sequence on the fly.
@@ -254,10 +249,35 @@ template genWithDb(connection, user, password, database: string, dbTypeNames: op
         Filter using ``cond`` condition.
         ]##
 
-        # Setting result len to 1 if limit is lower than 0 because genGetManyQuery
-        # requieres at least one object to get the db table name
-        result.setLen if limit < 0: 1 else: limit
+        result.setLen limit
         result.getMany(limit, offset, cond, params)
+
+      proc getAll(objs: var seq[object], cond = "TRUE", params: varargs[DbValue, dbValue]) {.used.} =
+        ##[ Read all records from DB into an existing open array of objects.
+        This is a dangerous operation as you don't control the amount of data received.
+
+        Filter using ``cond`` condition.
+        ]##
+
+        let getAllQuery = genGetAllQuery(objs[0], cond)
+
+        debug getAllQuery, " <- ", params.join(", ")
+
+        let rows = dbConn.getAllRows(getAllQuery, params)
+
+        objs.setLen rows.len
+
+        rows.to(objs)
+
+      proc getAll(T: typedesc, cond = "TRUE", params: varargs[DbValue, dbValue]): seq[T] {.used.} =
+        ##[ Read all records from DB into a sequence of objects, create the sequence on the fly.
+        This is a dangerous operation as you don't control the amount of data received.
+
+        Filter using ``cond`` condition.
+        ]##
+
+        result.setLen 1
+        result.getAll(cond, params)
 
       template update(obj: object, force = false) {.used.} =
         ##[ Update DB record with object field values.

--- a/src/norm/postgres/sqlgen.nim
+++ b/src/norm/postgres/sqlgen.nim
@@ -221,20 +221,23 @@ proc genGetOneQuery*(obj: object, condition: string): SqlQuery =
   sql "SELECT $# FROM $# WHERE $#" % [obj.getColumns(force=true).join(", "),
                                       type(obj).getTable(), condition]
 
-proc genGetManyQuery*(obj: object, condition: string, paramCount = 0, withLimit: bool = true): SqlQuery =
+proc genGetManyQuery*(obj: object, condition: string, paramCount = 0): SqlQuery =
   ## Generate ``SELECT`` query to fetch multiple records for an object.
-  var rawQuery: string = "SELECT $# FROM $# WHERE $# "
-  var rawQueryParams: seq[string] = @[
+
+  sql "SELECT $# FROM $# WHERE $# LIMIT $$$# OFFSET $$$#" % [
     obj.getColumns(force=true).join(", "),
     type(obj).getTable(),
     condition,
-    $(paramCount+1)
+    $(paramCount+1),
+    $(paramCount+2)
   ]
-  if withLimit:
-    rawQuery.add("LIMIT $$$# ")
-    rawQueryParams.add($(paramCount+2))
-  rawQuery.add("OFFSET $$$#")
-  sql rawQuery  % rawQueryParams
+
+proc genGetAllQuery*(obj: object, condition: string): SqlQuery =
+  ## Generate ``SELECT`` query to fetch all records for an object.
+
+  sql "SELECT $# FROM $# WHERE $#" % [obj.getColumns(force=true).join(", "),
+                                     type(obj).getTable(), condition]
+
 
 proc genUpdateQuery*(obj: object, force: bool): SqlQuery =
   ## Generate ``UPDATE`` query for an object.

--- a/src/norm/postgres/sqlgen.nim
+++ b/src/norm/postgres/sqlgen.nim
@@ -221,16 +221,20 @@ proc genGetOneQuery*(obj: object, condition: string): SqlQuery =
   sql "SELECT $# FROM $# WHERE $#" % [obj.getColumns(force=true).join(", "),
                                       type(obj).getTable(), condition]
 
-proc genGetManyQuery*(obj: object, condition: string, paramCount = 0): SqlQuery =
+proc genGetManyQuery*(obj: object, condition: string, paramCount = 0, withLimit: bool = true): SqlQuery =
   ## Generate ``SELECT`` query to fetch multiple records for an object.
-
-  sql "SELECT $# FROM $# WHERE $# LIMIT $$$# OFFSET $$$#" % [
+  var rawQuery: string = "SELECT $# FROM $# WHERE $# "
+  var rawQueryParams: seq[string] = @[
     obj.getColumns(force=true).join(", "),
     type(obj).getTable(),
     condition,
-    $(paramCount+1),
-    $(paramCount+2)
+    $(paramCount+1)
   ]
+  if withLimit:
+    rawQuery.add("LIMIT $$$# ")
+    rawQueryParams.add($(paramCount+2))
+  rawQuery.add("OFFSET $$$#")
+  sql rawQuery  % rawQueryParams
 
 proc genUpdateQuery*(obj: object, force: bool): SqlQuery =
   ## Generate ``UPDATE`` query for an object.

--- a/src/norm/sqlite/sqlgen.nim
+++ b/src/norm/sqlite/sqlgen.nim
@@ -217,6 +217,12 @@ proc genGetManyQuery*(obj: object, condition: string): SqlQuery =
   sql "SELECT $# FROM $# WHERE $# LIMIT ? OFFSET ?" % [obj.getColumns(force=true).join(", "),
                                                        type(obj).getTable(), condition]
 
+proc genGetAllQuery*(obj: object, condition: string): SqlQuery =
+  ## Generate ``SELECT`` query to fetch all records for an object.
+
+  sql "SELECT $# FROM $# WHERE $#" % [obj.getColumns(force=true).join(", "),
+                                     type(obj).getTable(), condition]
+
 proc genUpdateQuery*(obj: object, force: bool): SqlQuery =
   ## Generate ``UPDATE`` query for an object.
 

--- a/tests/tpostgres.nim
+++ b/tests/tpostgres.nim
@@ -162,27 +162,6 @@ suite "Creating and dropping tables, CRUD":
       check editions[0].id == 6
       check editions[^1].id == 9
 
-      users.getAll()
-      publishers.getAll()
-      books.getAll()
-      editions.getAll()
-
-      check len(users) == 9
-      check users[0].id == 1
-      check users[^1].id == 9
-
-      check len(publishers) == 9
-      check publishers[0].id == 1
-      check publishers[^1].id == 9
-
-      check len(books) == 9
-      check books[0].id == 1
-      check books[^1].id == 9
-
-      check len(editions) == 9
-      check editions[0].id == 1
-      check editions[^1].id == 9
-
       var
         user = User(birthDate: now(), lastLogin: now())
         publisher = Publisher()

--- a/tests/tpostgres.nim
+++ b/tests/tpostgres.nim
@@ -102,6 +102,26 @@ suite "Creating and dropping tables, CRUD":
       check editions[7].title == "Edition 8"
       check editions[7].book == books[7]
 
+    withDb:
+      let
+        publishers = Publisher.getAll()
+        books = Book.getAll()
+        editions = Edition.getAll()
+
+      check len(publishers) == 9
+      check len(books) == 9
+      check len(editions) == 9
+
+      check publishers[1].id == 2
+      check publishers[1].title == "Publisher 2"
+
+      check books[3].id == 4
+      check books[3].title == "Book 4"
+
+      check editions[8].id == 9
+      check editions[8].title == "Edition 9"
+      check editions[8].book == books[8]
+
   test "Read records":
     withDb:
       var
@@ -142,6 +162,27 @@ suite "Creating and dropping tables, CRUD":
       check editions[0].id == 6
       check editions[^1].id == 9
 
+      users.getAll()
+      publishers.getAll()
+      books.getAll()
+      editions.getAll()
+
+      check len(users) == 9
+      check users[0].id == 1
+      check users[^1].id == 9
+
+      check len(publishers) == 9
+      check publishers[0].id == 1
+      check publishers[^1].id == 9
+
+      check len(books) == 9
+      check books[0].id == 1
+      check books[^1].id == 9
+
+      check len(editions) == 9
+      check editions[0].id == 1
+      check editions[^1].id == 9
+
       var
         user = User(birthDate: now(), lastLogin: now())
         publisher = Publisher()
@@ -172,6 +213,18 @@ suite "Creating and dropping tables, CRUD":
 
       expect KeyError:
         let notExistingBook {.used.} = Book.getOne("title = $1", "Does not exist")
+
+    withDb:
+      let someBooks = Book.getAll(cond="title NOT IN (?, ?, ?) ORDER BY title DESC",
+                                  params=[?"Book 1", ?"Book 5", ?"Book 9"])
+
+      check len(someBooks) == 6
+
+      check someBooks[0].title == "Book 8"
+      check someBooks[1].authorEmail == "test-7@example.com"
+
+      check someBooks[5].title == "Book 2"
+      check someBooks[4].authorEmail == "test-3@example.com"
 
   test "Update records":
     withDb:

--- a/tests/tpostgres.nim
+++ b/tests/tpostgres.nim
@@ -215,7 +215,7 @@ suite "Creating and dropping tables, CRUD":
         let notExistingBook {.used.} = Book.getOne("title = $1", "Does not exist")
 
     withDb:
-      let someBooks = Book.getAll(cond="title NOT IN (?, ?, ?) ORDER BY title DESC",
+      let someBooks = Book.getAll(cond="title NOT IN ($1, $2, $3) ORDER BY title DESC",
                                   params=[?"Book 1", ?"Book 5", ?"Book 9"])
 
       check len(someBooks) == 6

--- a/tests/tsqlite.nim
+++ b/tests/tsqlite.nim
@@ -180,27 +180,6 @@ suite "Creating and dropping tables, CRUD":
       check editions[0].id == 6
       check editions[^1].id == 9
 
-      users.getAll()
-      publishers.getAll()
-      books.getAll()
-      editions.getAll()
-
-      check len(users) == 9
-      check users[0].id == 1
-      check users[^1].id == 9
-
-      check len(publishers) == 9
-      check publishers[0].id == 1
-      check publishers[^1].id == 9
-
-      check len(books) == 9
-      check books[0].id == 1
-      check books[^1].id == 9
-
-      check len(editions) == 9
-      check editions[0].id == 1
-      check editions[^1].id == 9
-
       var
         user = User(birthDate: now(), lastLogin: now())
         publisher = Publisher()

--- a/tests/tsqlite.nim
+++ b/tests/tsqlite.nim
@@ -120,6 +120,26 @@ suite "Creating and dropping tables, CRUD":
       check editions[7].title == "Edition 8"
       check editions[7].book == books[7]
 
+    withDb:
+      let
+        publishers = Publisher.getAll()
+        books = Book.getAll()
+        editions = Edition.getAll()
+
+      check len(publishers) == 9
+      check len(books) == 9
+      check len(editions) == 9
+
+      check publishers[1].id == 2
+      check publishers[1].title == "Publisher 2"
+
+      check books[3].id == 4
+      check books[3].title == "Book 4"
+
+      check editions[8].id == 9
+      check editions[8].title == "Edition 9"
+      check editions[8].book == books[8]
+
   test "Read records":
     withDb:
       var
@@ -160,6 +180,27 @@ suite "Creating and dropping tables, CRUD":
       check editions[0].id == 6
       check editions[^1].id == 9
 
+      users.getAll()
+      publishers.getAll()
+      books.getAll()
+      editions.getAll()
+
+      check len(users) == 9
+      check users[0].id == 1
+      check users[^1].id == 9
+
+      check len(publishers) == 9
+      check publishers[0].id == 1
+      check publishers[^1].id == 9
+
+      check len(books) == 9
+      check books[0].id == 1
+      check books[^1].id == 9
+
+      check len(editions) == 9
+      check editions[0].id == 1
+      check editions[^1].id == 9
+
       var
         user = User(birthDate: now(), lastLogin: now())
         publisher = Publisher()
@@ -190,6 +231,18 @@ suite "Creating and dropping tables, CRUD":
 
       expect KeyError:
         let notExistingBook {.used.} = Book.getOne("title=?", "Does not exist")
+
+    withDb:
+      let someBooks = Book.getAll(cond="title NOT IN (?, ?, ?) ORDER BY title DESC",
+                                  params=[?"Book 1", ?"Book 5", ?"Book 9"])
+
+      check len(someBooks) == 6
+
+      check someBooks[0].title == "Book 8"
+      check someBooks[1].authorEmail == "test-7@example.com"
+
+      check someBooks[5].title == "Book 2"
+      check someBooks[4].authorEmail == "test-3@example.com"
 
   test "Update records":
     withDb:


### PR DESCRIPTION
I've set the getMany's limit parameter to an optional parameter with default value -1. On sqlite we can pass a negtaive number to ignore `LIMIT`. On postgresql negative numbers are not allowed (instead of a negative number it must be `LIMIT ALL`). So I've modified the `genGetManyQuery`, that `LIMIT` will not be added to the query if the parameter `withLimit` (default true) is set to false. I think it's not the optimal solution, but I have not found a better for this.