### PR TITLE
Require ndb >= 0.19.8.

### DIFF
--- a/norm.nimble
+++ b/norm.nimble
@@ -9,4 +9,4 @@ srcDir        = "src"
 
 # Dependencies
 
-requires "nim >= 1.0.0", "ndb#head"
+requires "nim >= 1.0.0", "ndb >= 0.19.8"


### PR DESCRIPTION
Probably this was the cause of #46.