### PR TITLE
Attempt to deprecate NOT NULL

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -8,6 +8,7 @@
 
 ## 1.1.0 (WIP)
 
+-   [!] Deprecate `notNull` pragma, `NOT NULL` is the default for all types except `Option` types
 -   [!] Rename pragma `table` to `dbTable`.
 -   [!] Deprecate `default` pragma, always add default values to tables instead.
 -   [!][+] Rewrite PostgreSQL backend to use [ndb](https://github.com/xzfc/ndb.nim), which adds `NULL` support via `Option` type similarly to SQLite backend.

--- a/src/norm/postgres/sqlgen.nim
+++ b/src/norm/postgres/sqlgen.nim
@@ -110,8 +110,6 @@ proc genColStmt(fieldRepr: FieldRepr): string =
       result.add " PRIMARY KEY"
     elif prag.name == "unique" and prag.kind == pkFlag:
       result.add " UNIQUE"
-    elif prag.name == "notNull" and prag.kind == pkFlag:
-      result.add " NOT NULL"
     elif prag.name == "check" and prag.kind == pkKval:
       result.add " CHECK $#" % $prag.value
     elif prag.name == "fk" and prag.kind == pkKval:

--- a/src/norm/pragmas.nim
+++ b/src/norm/pragmas.nim
@@ -34,8 +34,12 @@ template default*(val: string) {.
   pragma, deprecated: "Default values are set automatically, this is ignored.".}
   ## Default value for the DB column.
 
-template notNull* {.pragma.}
-  ## Add ``NOT NULL`` constraint.
+template notNull* {.
+  pragma, deprecated: "NOT NULL is the default with all fields exception Options, this is ignored.".}
+  ##[ Add ``NOT NULL`` constraint.
+  
+  **Deprecated.** NOT NULL is the default with all fields exception Options, this is ignored.
+  ]##
 
 template check*(val: string) {.pragma.}
   ## Add a ``CHECK <CONDITION>`` constraint.

--- a/src/norm/pragmas.nim
+++ b/src/norm/pragmas.nim
@@ -36,10 +36,7 @@ template default*(val: string) {.
 
 template notNull* {.
   pragma, deprecated: "NOT NULL is the default with all fields exception Options, this is ignored.".}
-  ##[ Add ``NOT NULL`` constraint.
-  
-  **Deprecated.** NOT NULL is the default with all fields exception Options, this is ignored.
-  ]##
+  ## Add ``NOT NULL`` constraint.
 
 template check*(val: string) {.pragma.}
   ## Add a ``CHECK <CONDITION>`` constraint.

--- a/src/norm/sqlite/sqlgen.nim
+++ b/src/norm/sqlite/sqlgen.nim
@@ -102,8 +102,6 @@ proc genColStmt(fieldRepr: FieldRepr): string =
       result.add " PRIMARY KEY"
     elif prag.name == "unique" and prag.kind == pkFlag:
       result.add " UNIQUE"
-    elif prag.name == "notNull" and prag.kind == pkFlag:
-      result.add " NOT NULL"
     elif prag.name == "check" and prag.kind == pkKval:
       result.add " CHECK $#" % $prag.value
     elif prag.name == "fk" and prag.kind == pkKval:


### PR DESCRIPTION
I attempted to replicate [this pull](https://github.com/moigagoo/norm/pull/33/files) for `NOT NULL`. I'm not sure if anything else is needed, but it looks good to me.