### PR TITLE
RFC: Add ability to create test transaction

### DIFF
--- a/src/norm/postgres.nim
+++ b/src/norm/postgres.nim
@@ -291,3 +291,26 @@ template transaction*(dbConn; body: untyped): untyped =
       debug rollbackQry
     dbConn.exec(sql rollbackQry)
     raise
+
+template testTransaction*(dbConn; body: untyped): untyped =
+  ##[ Wrap code in DB test transaction.
+
+  This is useful for unit testing database operations in isloation.
+
+  ]##
+
+  let
+    beginQry = "BEGIN"
+    rollbackQry = "ROLLBACK"
+
+  try:
+    when defined(normDebug):
+      debug beginQry
+    dbConn.exec(sql beginQry)
+
+    body
+
+  finally:
+    when defined(normDebug):
+      debug rollbackQry
+    dbConn.exec(sql rollbackQry)

--- a/src/norm/sqlite.nim
+++ b/src/norm/sqlite.nim
@@ -284,3 +284,26 @@ template transaction*(dbConn; body: untyped): untyped =
       debug rollbackQry
     dbConn.exec(sql rollbackQry)
     raise
+
+template testTransaction*(dbConn; body: untyped): untyped =
+  ##[ Wrap code in DB test transaction.
+
+  This is useful for unit testing database operations in isloation.
+
+  ]##
+
+  let
+    beginQry = "BEGIN"
+    rollbackQry = "ROLLBACK"
+
+  try:
+    when defined(normDebug):
+      debug beginQry
+    dbConn.exec(sql beginQry)
+
+    body
+
+  finally:
+    when defined(normDebug):
+      debug rollbackQry
+    dbConn.exec(sql rollbackQry)

--- a/tests/postgres/ttransactions.nim
+++ b/tests/postgres/ttransactions.nim
@@ -63,3 +63,21 @@ suite "Transactions":
 
     let rows = dbConn.getAllRows(sql"""SELECT price, id FROM "Toy"""")
     check rows.len == 0
+
+  test "Test transaction rollbacks after run":
+    dbConn.testTransaction:
+      let top = newToy().dup(dbConn.insert)
+      let uncommitedRows = dbConn.getAllRows(sql""" SELECT price, id FROM "Toy" """)
+      check uncommitedRows.len == 1
+
+    let rows = dbConn.getAllRows(sql""" SELECT price, id FROM "Toy" """)
+    check rows.len == 0
+
+  test "Test transaction rollbacks on exception":
+    expect ValueError:
+      dbConn.testTransaction:
+        let top = newToy().dup(dbConn.insert)
+        raise newException(ValueError, "Something went wrong")
+
+    let rows = dbConn.getAllRows(sql""" SELECT price, id FROM "Toy" """)
+    check rows.len == 0

--- a/tests/sqlite/ttransactions.nim
+++ b/tests/sqlite/ttransactions.nim
@@ -55,3 +55,21 @@ suite "Transactions":
 
     let rows = dbConn.getAllRows(sql"SELECT price, id FROM Toy")
     check rows.len == 0
+
+  test "Test Transaction rollbacks after run":
+    dbConn.testTransaction:
+      let top = newToy().dup(dbConn.insert)
+      let uncommitedRows = dbConn.getAllRows(sql""" SELECT price, id FROM "Toy" """)
+      check uncommitedRows.len == 1
+
+    let rows = dbConn.getAllRows(sql""" SELECT price, id FROM "Toy" """)
+    check rows.len == 0
+
+  test "Test transaction rollbacks on exception":
+    expect ValueError:
+      dbConn.testTransaction:
+        let top = newToy().dup(dbConn.insert)
+        raise newException(ValueError, "Something went wrong")
+
+    let rows = dbConn.getAllRows(sql""" SELECT price, id FROM "Toy" """)
+    check rows.len == 0


### PR DESCRIPTION
## Why this?
In other stacks (e.g. rails, elixir) provides a sandbox transaction for test env. This makes testing database interaction easily and confidently.  
The rollback after each test ensures that database remains side-effect free.

## Apporach
Create a `dbConn` which always rollbacks and inject as dependency.

Assuming `MyTask` is a valid model.
e.g.

```nim
proc listAllTasks*(dbConn: DbConn): seq[MyTask] =
  var tasks = @[newMyTask()]
  dbConn.selectAll(tasks)
  result = tasks
```

can be tested like with `dbConn.testTransaction` ?

```nim
  test "get list of all tasks":
    dbConn.testTransaction:
      var task = newMyTask("doThis", "gahan")
      dbConn.insert(task)
      let uncommittedRows = listAllTasks(dbConn)
      check(uncommittedRows.len == 1)

    check(listAllTasks(dbConn).len == 0)
```

This frees the db clean up tasks for unit testing.
> P.S. This only works if `DbConn` is injected.
