### PR TITLE
Added some docs for querying nested relationships

### DIFF
--- a/book/tutorial/rows.nim
+++ b/book/tutorial/rows.nim
@@ -97,6 +97,34 @@ nbCode:
     echo customer.user[]
 
 nbText: """
+
+If you query relationships that are nested, such as when customers can have pets and you want to query all pets of all customers of users with a specific email address, you will need  to concatenate the foreign-key fields, separeted by a `_` in your query.
+"""
+
+nbCode:
+  import norm/model
+
+  type Pet* = ref object of Model
+    name*: string
+    owner*: Customer
+
+  func newPet*(name = "", owner = newCustomer()): Pet =
+    Pet(name: name, owner: owner)
+  
+  dbConn.createTables(newPet())
+  
+  var fluffi: Pet = newPet("Fluffi", bob)
+  dbConn.insert(fluffi)
+
+
+  var petsFoo = @[newPet()]
+  dbConn.select(petsFoo, "owner_user.email LIKE ?", "foo%")
+
+  for pet in petsFoo:
+    echo pet[]
+
+nbText: """
+
 ### Selecting Many-To-One/One-To-Many relationships
 Imagine you had a Many-To-One relationship between two models, like we have with `Customer` being the many-model and `User` being the one-model, where one user can have many customers. 
 
@@ -147,8 +175,6 @@ As before, if your join-model (e.g. UserGroup) only has a single field pointing 
 """
 
 nbCode:
-  import norm/model
-
   type
     Group* = ref object of Model
       name*: string


### PR DESCRIPTION
Stumbled over this one and thought documentation might be nice.
Basically I had 3 tables: Campaigns (a dnd campaign), Session (a single dnd session that is part of a campaign), Diaryentries (notes about a single session from one specific person). Session's FK-column to Campaign was called "campaign_id", diaryentries FK-column to Session was called "session_id". 

I wanted to query all Diaryentries for a campaign with a specific name, which is a nested relationship since that isn't a field directly on Session nor Diaryentry, so I had to figure out how to write that "WHERE"-condition and noticed that it's basically just concatenating the FK_fields with "_".

So I could just write the condition`session_id_campaign_id.name LIKE ?`. Given that it's not incredibly unlikely to want to do this type of query, I though adding docs for it and that norm supports it could be useful.