### PR TITLE
Feature/143 better error message

### DIFF
--- a/src/norm/model.nim
+++ b/src/norm/model.nim
@@ -190,9 +190,8 @@ proc validateFkField*[S, T: Model](fkFieldName: static string, source: typedesc[
 
 proc validateJoinModelFkField*[S, T: Model](fkFieldName: static string, joinModel: typedesc[S], target: typedesc[T]): bool {.compileTime.} =
   ## Checks at compile time whether the field with the name `fkFieldName` is a 
-  ## valid foreign key field on the given `source` model to the table of the given 
-  ## `target` model. Additionally, it also checks whether the joinModel links to
-  ## target type on its field `fkFieldName` by being a Model type of type `target`. 
+  ## valid foreign key field on the given `joinModel` model to the given 
+  ## `target` model. Ensures that the type in the field `fkFieldName` is `target` 
   ## If it isn't the code won't compile as that Model type is required for a useful
   ## Many-To-Many query.
   let tmp = validateFkField(fkFieldName, joinModel, target)

--- a/src/norm/model.nim
+++ b/src/norm/model.nim
@@ -187,3 +187,24 @@ proc validateFkField*[S, T: Model](fkFieldName: static string, source: typedesc[
       return true
 
   return false
+
+proc validateJoinModelFkField*[S, T: Model](fkFieldName: static string, joinModel: typedesc[S], target: typedesc[T]): bool {.compileTime.} =
+  ## Checks at compile time whether the field with the name `fkFieldName` is a 
+  ## valid foreign key field on the given `source` model to the table of the given 
+  ## `target` model. Additionally, it also checks whether the joinModel links to
+  ## target type on its field `fkFieldName` by being a Model type of type `target`. 
+  ## If it isn't the code won't compile as that Model type is required for a useful
+  ## Many-To-Many query.
+  let tmp = validateFkField(fkFieldName, joinModel, target)
+  
+  for joinFieldName, joinFieldValue in joinModel()[].fieldPairs:
+    when joinFieldName == fkFieldName:
+      #Handles case where field is an int with fk pragma
+      const joinModelName = name(joinModel)
+      const targetModelName = name(target)
+      const actualType = name(joinFieldValue.type())
+      assert(joinFieldValue is target, fmt"Tried using an invalid join model. Field '{joinModelName}.{fkFieldName}' was not of the required type `{targetModelName}`, but of type `{actualType}`!")
+
+      return true
+
+  return false

--- a/src/norm/postgres.nim
+++ b/src/norm/postgres.nim
@@ -396,7 +396,7 @@ proc selectManyToMany*[M1: Model, J: Model, M2: Model](dbConn; queryStartEntry: 
   ## Will not compile if the specified fields on the joinModel do not properly point
   ## to the tables of `queryStartEntry` and `queryEndEntries`.
   static: discard validateFkField(fkColumnFromJoinToManyStart, J, M1)
-  static: discard validateFkField(fkColumnFromJoinToManyEnd, J, M2)
+  static: discard validateJoinModelFkField(fkColumnFromJoinToManyEnd, J, M2)
 
   const joinTableName = J.table()
   const sqlCondition: string = fmt "{joinTableName}.{fkColumnFromJoinToManyStart} = $1"

--- a/src/norm/postgres.nim
+++ b/src/norm/postgres.nim
@@ -396,7 +396,7 @@ proc selectManyToMany*[M1: Model, J: Model, M2: Model](dbConn; queryStartEntry: 
   ## Will not compile if the specified fields on the joinModel do not properly point
   ## to the tables of `queryStartEntry` and `queryEndEntries`.
   const tmp1 = validateFkField(fkColumnFromJoinToManyStart, J, M1) # 'tmp1' is irrelevant, but the assignment is required for 'validateFkField' to run properly
-  const tmp2 = validateFkField(fkColumnFromJoinToManyEnd, J, M2) # 'tmp2' is irrelevant, but the assignment is required for 'validateFkField' to run properly 
+  const tmp2 = validateJoinModelFkField(fkColumnFromJoinToManyEnd, J, M2) # 'tmp2' is irrelevant, but the assignment is required for 'validateFkField' to run properly 
   
   const joinTableName = J.table()
   const sqlCondition: string = fmt "{joinTableName}.{fkColumnFromJoinToManyStart} = $1"

--- a/src/norm/sqlite.nim
+++ b/src/norm/sqlite.nim
@@ -391,7 +391,7 @@ proc selectManyToMany*[M1: Model, J: Model, M2: Model](dbConn; queryStartEntry: 
   ## Will not compile if the specified fields on the joinModel do not properly point
   ## to the tables of `queryStartEntry` and `queryEndEntries`.
   static: discard validateFkField(fkColumnFromJoinToManyStart, J, M1) # 'tmp1' is irrelevant, but the assignment is required for 'validateFkField' to run properly
-  static: discard validateFkField(fkColumnFromJoinToManyEnd, J, M2) # 'tmp2' is irrelevant, but the assignment is required for 'validateFkField' to run properly 
+  static: discard validateJoinModelFkField(fkColumnFromJoinToManyEnd, J, M2) # 'tmp2' is irrelevant, but the assignment is required for 'validateFkField' to run properly 
   
   const joinTableName = J.table()
   const sqlCondition: string = "$#.$# = ?" % [joinTableName, fkColumnFromJoinToManyStart]

--- a/src/norm/sqlite.nim
+++ b/src/norm/sqlite.nim
@@ -391,8 +391,8 @@ proc selectManyToMany*[M1: Model, J: Model, M2: Model](dbConn; queryStartEntry: 
   ## Will not compile if the specified fields on the joinModel do not properly point
   ## to the tables of `queryStartEntry` and `queryEndEntries`.
   const tmp1 = validateFkField(fkColumnFromJoinToManyStart, J, M1) # 'tmp1' is irrelevant, but the assignment is required for 'validateFkField' to run properly
-  const tmp2 = validateFkField(fkColumnFromJoinToManyEnd, J, M2) # 'tmp2' is irrelevant, but the assignment is required for 'validateFkField' to run properly 
-  
+  const tmp2 = validateJoinModelFkField(fkColumnFromJoinToManyEnd, J, M2) # 'tmp2' is irrelevant, but the assignment is required for 'validateFkField' to run properly 
+
   const joinTableName = J.table()
   const sqlCondition: string = "$#.$# = ?" % [joinTableName, fkColumnFromJoinToManyStart]
   dbConn.select(joinModelEntries, sqlCondition, queryStartEntry.id)


### PR DESCRIPTION
PR for #143 

Fixes the fact that, if you were to use `selectManyToMany` with a model like this:

```nim
type CharacterEncounterConnection* {.tableName: ENCOUNTER_CHARACTER_TABLE.} = ref object of Model
    character_id* {.fk: Character.}: int64
   encounter_id* {.fk: Encounter.}: int64

    let joinModelSeq =  @[CharacterEncounterConnection(character_id: -1, enocunter_id: -1)]
    let targetSeq = @[Encounter(title: "")]
    connection.selectManyToMany(entry, joinModelSeq, targetSeq)
```

You would get completely useless error messages such as this:

```nim
Error: type mismatch: got 'seq[int64]' for '
type
  OutType`gensym103 = typeof(
    block:
      var it: typeof(items(joinModelEntries), typeOfIter)
      it.encounter_id, typeOfProc)
block:
  let :tmp_5066724439 = joinModelEntries
  template s2_5066724440(): untyped =
    :tmp_5066724439
  
  var i`gensym103 = 0
  var result`gensym103 = newSeq(len(:tmp_5066724439))
  for it in items(:tmp_5066724439):
    result`gensym103[i`gensym103] = it.encounter_id
    i`gensym103 += 1
  result`gensym103' but expected 'seq[EncounterRead]'
```

Now you get something readable like this:

```nim
Error: unhandled exception: /home/philipp/dev/norm/src/norm/model.nim(204, 13) `joinModel()[].specialty is target` Tried using an invalid join model. Field 'BadSpecialtyJoinModel.specialty' was not of the required type `Specialty`, but of type `int64`! [AssertionDefect]
```