### PR TITLE
Feature/142 multi many to many query procs

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,16 @@
 -   [t]—test suite improvement
 -   [d]—docs improvement
 
+## 2.5.0 (July 7, 2022)
+
+- [+] Added `selectOneToMany` proc overload that is able to query multiple many-to-one relationships at once (see [#142](https://github.com/moigagoo/norm/issues/142))
+- [+] Added `selectManyToMany` proc overload that is able to query multiple many-to-many relationships at once (see [#142](https://github.com/moigagoo/norm/issues/142))
+- [f] Fixed compile-time assertions creating unused variables
+- [d] Added small hint that placeholders in postgres is done via `$1`, `S2`... etc
+- [d] Added links to norman, example app, the API index and these nimibook docs
+- [r] Added better compile-time error message should a user be trying to query a many-to-many relationship with a join-model that doesn't provide the necessary type for the query-end models.
+
+
 ## 2.4.0 (March 7, 2022)
 
 -   [+] Added `selectOneToMany` proc to query many-to-one relationships (see [#127](https://github.com/moigagoo/norm/issues/127))

--- a/src/norm/sqlite.nim
+++ b/src/norm/sqlite.nim
@@ -402,6 +402,17 @@ proc selectOneToMany*[O: Model, M: Model](dbConn; oneEntries: seq[O], relatedEnt
     let id = entryId
     relatedEntries[entryId] = relatedEntriesSeq.filter(target => target.dot(foreignKeyFieldName).id == id)
 
+proc selectOneToMany*[O: Model, M: Model](dbConn; oneEntries: seq[O], relatedEntries: var seq[M]) =
+  ## A convenience proc. Fetches all entries of multiple "many" side from multiple 
+  ## one-to-many relationships between the entries within `oneEntries` and the model 
+  ## of `relatedEntries`. This is done with a single query to the database. 
+  ## The field used to fetch the `relatedEntries` is automatically inferred as long as 
+  ## the `relatedEntries` model has only one field pointing to the model of `oneEntries`. 
+  ## Will not compile if `relatedEntries` has multiple fields that point to the 
+  ## model of `oneEntry`. Specify the `foreignKeyFieldName` parameter in such a
+  ## case.
+  const foreignKeyFieldName: string = M.getRelatedFieldNameTo(O)
+  selectOneToMany(dbConn, oneEntries, relatedEntries, foreignKeyFieldName)
 
 macro unpackFromJoinModel[T: Model](mySeq: seq[T], field: static string): untyped =
   ## A macro to "extract" a field of name `field` out of the model in `mySeq`, 

--- a/src/norm/sqlite.nim
+++ b/src/norm/sqlite.nim
@@ -1,4 +1,4 @@
-import std/[os, logging, strutils, sequtils, options, sugar]
+import std/[os, logging, strutils, sequtils, options, sugar, strformat, tables, sets]
 
 when (NimMajor, NimMinor) <= (1, 6):
   import pragmasutils
@@ -376,6 +376,33 @@ proc selectOneToMany*[O: Model, M: Model](dbConn; oneEntry: O, relatedEntries: v
   const foreignKeyFieldName: string = M.getRelatedFieldNameTo(O)
   selectOneToMany(dbConn, oneEntry, relatedEntries, foreignKeyFieldName)
 
+proc selectOneToMany*[O: Model, M: Model](dbConn; oneEntries: seq[O], relatedEntries: var Table[int64, seq[M]], foreignKeyFieldName: static string) =
+  ## Fetches all entries of multiple "many" side from multiple one-to-many relationships
+  ## between the entries within `oneEntries` and the model of `relatedEntries`. This is 
+  ## done with a single query to the database. The various many-to-one relationships are
+  ## split into a table, where the id of each entry in `oneEntries` is mapped to the entries
+  ## pointing to it. It is ensured at compile time that the field specified here is a 
+  ## valid foreign key field on oneEntry pointing to the table of the `relatedEntries`-model.
+  ## `relatedEntries` must contain at least 1 entry with a seq that contains a model instance.
+  let entryIds: seq[int64] = oneEntries.map(entry => entry.id)
+
+  var relatedEntriesSeq: seq[M] = @[]
+  for key in relatedEntries.keys:
+    if relatedEntries[key].len() > 0:
+      relatedEntriesSeq = relatedEntries[key]
+  assert(relatedEntriesSeq.len() > 0, "Failed to execute `selectOneToMany` for multiple entries. At least one of the seq's within `relatedEntries` must contain 1 or more model instances")
+
+  let idString = entryIds.map(id => id.int.intToStr()).join(",")
+  const manyTable = M.table()
+  let condition = fmt"{manyTable}.{foreignKeyFieldName} IN ({idString})"
+
+  dbConn.select(relatedEntriesSeq, condition)
+
+  for entryId in entryIds:
+    let id = entryId
+    relatedEntries[entryId] = relatedEntriesSeq.filter(target => target.dot(foreignKeyFieldName).id == id)
+
+
 macro unpackFromJoinModel[T: Model](mySeq: seq[T], field: static string): untyped =
   ## A macro to "extract" a field of name `field` out of the model in `mySeq`, 
   ## creating a new seq of whatever type the field called `field` has.
@@ -416,3 +443,35 @@ proc selectManyToMany*[M1: Model, J: Model, M2: Model](dbConn; queryStartEntry: 
   const fkColumnFromJoinToManyStart: string = J.getRelatedFieldNameTo(M1)
   const fkColumnFromJoinToManyEnd: string = J.getRelatedFieldNameTo(M2)
   selectManyToMany(dbConn, queryStartEntry, joinModelEntries, queryEndEntries, fkColumnFromJoinToManyStart, fkColumnFromJoinToManyEnd)
+
+proc selectManyToMany*[M1: Model, J: Model, M2: Model](
+    dbConn; 
+    queryStartEntries: seq[M1], 
+    joinModelEntries: var seq[J], 
+    queryEndEntries: var Table[int64, seq[M2]], 
+    fkColumnFromJoinToManyStart: static string, 
+    fkColumnFromJoinToManyEnd: static string
+) =
+  ## Fetches the many-to-many relationship for all members of `queryStartEntries` and
+  ## stores them in the table of `queryEndEntries`. There, all entries connected to a 
+  ## given member of `queryStartEntry` are mapped to that members id`. 
+  ## Requires to also be passed the model connecting the many-to-many relationship
+  ## via `joinModelEntries`in order to fetch the relationship, and the name of its fields
+  ## that point to the model of `queryStartEntries` (`fkColumnFromJoinToManyStart`) 
+  ## and `queryEndEntries` (`fkColumnFromJoinToManyEnd`).
+  ## Will not compile if the specified fields on the joinModel do not properly point
+  ## to the models of `queryStartEntry` and `queryEndEntries`.
+  let queryStartEntryIds: seq[int64] = queryStartEntries.map(entry => entry.id).deduplicate()
+
+  let idString = queryStartEntryIds.map(id => id.int.intToStr()).join(",")
+  const joinTableName = J.table()
+  let sqlCondition: string = fmt"{joinTableName}.{fkColumnFromJoinToManyStart} IN ({idString})"
+
+  dbConn.select(joinModelEntries, sqlCondition)
+
+  for entryId in queryStartEntryIds:
+    queryEndEntries[entryId] = @[]
+
+    for joinModelEntry in joinModelEntries:
+      if joinModelEntry.dot(fkColumnFromJoinToManyStart).id == entryId:
+        queryEndEntries[entryId].add(joinModelEntry.dot(fkColumnFromJoinToManyEnd))

--- a/src/norm/sqlite.nim
+++ b/src/norm/sqlite.nim
@@ -352,10 +352,11 @@ template transaction*(dbConn; body: untyped): untyped =
     raise
 
 proc selectOneToMany*[O: Model, M: Model](dbConn; oneEntry: O, relatedEntries: var seq[M], foreignKeyFieldName: static string) =
-  ## Fetches all entries of a "many" side from a one-to-many relationship 
-  ## between the model of `oneEntry` and the model of `relatedEntries`. It is
-  ## ensured at compile time that the field specified here is a valid foreign key
-  ## field on oneEntry pointing to the table of the `relatedEntries`-model.
+  ## Fetches all entries of a "many" side from the single one-to-many relationship 
+  ## between the model of `oneEntry` and the model of `relatedEntries` and
+  ## puts them into `relatedEntries`. It is ensured at compile time that the 
+  ## field specified here is a valid foreign key field on oneEntry pointing to 
+  ## the table of the `relatedEntries`-model.
   const _ = validateFkField(foreignKeyFieldName, M, O) # '_' is irrelevant, but the assignment is required for 'validateFkField' to run properly
 
   const manyTableName = M.table()
@@ -364,13 +365,14 @@ proc selectOneToMany*[O: Model, M: Model](dbConn; oneEntry: O, relatedEntries: v
   dbConn.select(relatedEntries, sqlCondition, oneEntry.id)
 
 proc selectOneToMany*[O: Model, M: Model](dbConn; oneEntry: O, relatedEntries: var seq[M]) =
-  ## A convenience proc. Fetches all entries of a "many" side from a one-to-many 
-  ## relationship between the model of `oneEntry` and the model of `relatedEntries`.
-  ## The field used to fetch the `relatedEntries` is automatically inferred as long
-  ## as the `relatedEntries` model has only one field pointing to the model of 
-  ## `oneEntry`. Will not compile if `relatedEntries` has multiple fields that 
-  ## point to the model of `oneEntry`. Specify the `foreignKeyFieldName` parameter 
-  ## in such a case.
+  ## A convenience proc. Fetches all entries of a "many" side from the single one-to-many 
+  ## relationship between the model of `oneEntry` and the model of `relatedEntries`
+  ## puts them into `relatedEntries`. The field used to fetch the `relatedEntries` 
+  ## is automatically inferred as long as the `relatedEntries` model has only one 
+  ## field pointing to the model of `oneEntry`. 
+  ## Will not compile if `relatedEntries` has multiple fields that point to the 
+  ## model of `oneEntry`. Specify the `foreignKeyFieldName` parameter in such a
+  ## case.
   const foreignKeyFieldName: string = M.getRelatedFieldNameTo(O)
   selectOneToMany(dbConn, oneEntry, relatedEntries, foreignKeyFieldName)
 

--- a/src/norm/sqlite.nim
+++ b/src/norm/sqlite.nim
@@ -475,3 +475,24 @@ proc selectManyToMany*[M1: Model, J: Model, M2: Model](
     for joinModelEntry in joinModelEntries:
       if joinModelEntry.dot(fkColumnFromJoinToManyStart).id == entryId:
         queryEndEntries[entryId].add(joinModelEntry.dot(fkColumnFromJoinToManyEnd))
+
+proc selectManyToMany*[M1: Model, J: Model, M2: Model](
+    dbConn; 
+    queryStartEntries: seq[M1], 
+    joinModelEntries: var seq[J], 
+    queryEndEntries: var Table[int64, seq[M2]]
+) =
+  ## A convenience proc. Fetches the many-to-many relationship for all members of 
+  ## `queryStartEntries` and stores them in the table of `queryEndEntries`. There, 
+  ## all entries connected to a given member of `queryStartEntry` are mapped to that 
+  ## members id`.
+  ## Requires to also be passed the model connecting the many-to-many relationship via 
+  ## `joinModelEntries`in order to fetch the relationship.
+  ## The fields on `joinModelEntries` to use for these queries are inferred. 
+  ## Will only compile if the joinModel has exactly one field pointing to 
+  ## the table of `queryStartEntry` as well as exactly one field pointing to 
+  ## the table of `queryEndEntries`. Specify the parameters `fkColumnFromJoinToManyStart`
+  ## and `fkColumnFromJoinToManyEnd` if that is not the case.
+  const fkColumnFromJoinToManyStart: string = J.getRelatedFieldNameTo(M1)
+  const fkColumnFromJoinToManyEnd: string = J.getRelatedFieldNameTo(M2)
+  selectManyToMany(dbConn, queryStartEntries, joinModelEntries, queryEndEntries, fkColumnFromJoinToManyStart, fkColumnFromJoinToManyEnd)

--- a/tests/sqlite/trelated.nim
+++ b/tests/sqlite/trelated.nim
@@ -61,7 +61,7 @@ suite "Testing selectOneToMany proc":
     check doctorVisits.len() == 1
     check doctorVisits[0].doctor === someDoctor
 
-  test "Given 2 Models with a many-to-one relationship between two models When you want to fetch the relationship for multiple entries at once, Then return a table where the id of each entry is mapped to their related entries":
+  test "Given 2 Models with a many-to-one relationship between them, When you want to fetch the relationship for 2 entries at once, Then return a table with 2 entries where the id of each entry is mapped to their related entries":
     #Given
     let patients: seq[Person] = @[alice, bob]
 
@@ -71,11 +71,27 @@ suite "Testing selectOneToMany proc":
     dbConn.selectOneToMany(patients, doctorVisits, "patient")
 
     #Then
+    check doctorVisits.len() == 2
     check doctorVisits[alice.id].len() == 1
     check doctorVisits[alice.id][0].doctor === someDoctor
     check doctorVisits[bob.id].len() == 1
     check doctorVisits[bob.id][0].doctor === someDoctor
 
+
+  test "Given 2 Models with a many-to-one relationship between them, When you want to fetch the relationship for one entry, Then return a table with 1 entry where the id is mapped to the related entries":
+    #Given
+    let patients: seq[Person] = @[alice]
+
+    #When
+    var doctorVisits: tables.Table[int64, seq[DoctorVisit]] = initTable[int64, seq[DoctorVisit]]()
+    doctorVisits[alice.id] = @[newDoctorVisit()]
+    dbConn.selectOneToMany(patients, doctorVisits, "patient")
+
+    #Then
+    check doctorVisits.len() == 1
+    check doctorVisits[alice.id].len() == 1
+    check doctorVisits[alice.id][0].doctor === someDoctor
+  
 
   test "When there is multiple many-to-one relationships between two models and the type field for fetching the desired relationship is specified, then fetch the entries of that relationship":
     var doctorVisits: seq[DoctorVisit] = @[newDoctorVisit()]
@@ -227,4 +243,3 @@ suite "Testing selectManyToMany":
     var petSeq: seq[Pet] = @[newPet()]
     var specialtyRelationship: seq[DoctorSpecialties] = @[newDoctorSpecialties()]
     check compiles(dbConn.selectManyToMany(acula, specialtyRelationship, petSeq)) == false
-     


### PR DESCRIPTION
THIS PR IS NOT FINISHED!

PR for #142 

What is missing is : 
1) another version of `selectManyToMany` and `selectOneToMany` without the additional parameters `foreignKeyFieldName` / `fkColumnFromJoinToManyStart` , `fkColumnFromJoinToManyEnd` ! 
2) The same procs but for postgres
3) Tests!

This is barely a first draft implementation that works and a first set of tests to cover only a single usecase.

Before I write the rest, I'd want to double check with you though whether the implementation in general looks as you'd want it to. Once we have that worked out I'll apply whatever fixes are necessary and write the remaining tests.