### PR TITLE
replaced useless variable assignments

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,11 @@
 -   [t]—test suite improvement
 -   [d]—docs improvement
 
+## 2.4.1 (Jun 23, 2022)
+
+-   [r] Replaced pointless variable assignments at compile time with `static discard`
+-   [r] Improved error message you receive when using `selectManyToMany` with an invalid joinModel
+
 ## 2.4.0 (March 7, 2022)
 
 -   [+] Added `selectOneToMany` proc to query many-to-one relationships (see [#127](https://github.com/moigagoo/norm/issues/127))

--- a/src/norm/postgres.nim
+++ b/src/norm/postgres.nim
@@ -361,8 +361,8 @@ proc selectOneToMany*[O: Model, M: Model](dbConn; oneEntry: O, relatedEntries: v
   ## between the model of `oneEntry` and the model of `relatedEntries`. It is
   ## ensured at compile time that the field specified here is a valid foreign key
   ## field on oneEntry pointing to the table of the `relatedEntries`-model.
-  const _ = validateFkField(foreignKeyFieldName, M, O) # '_' is irrelevant, but the assignment is required for 'validateFkField' to run properly at compileTime
-
+  static: discard validateFkField(foreignKeyFieldName, M, O)
+  
   const manyTableName = M.table()
   const sqlCondition = fmt "{manyTableName}.{foreignKeyFieldName} = $1"
 
@@ -395,9 +395,9 @@ proc selectManyToMany*[M1: Model, J: Model, M2: Model](dbConn; queryStartEntry: 
   ## `fkColumnFromJoinToManyEnd`.
   ## Will not compile if the specified fields on the joinModel do not properly point
   ## to the tables of `queryStartEntry` and `queryEndEntries`.
-  const tmp1 = validateFkField(fkColumnFromJoinToManyStart, J, M1) # 'tmp1' is irrelevant, but the assignment is required for 'validateFkField' to run properly
-  const tmp2 = validateFkField(fkColumnFromJoinToManyEnd, J, M2) # 'tmp2' is irrelevant, but the assignment is required for 'validateFkField' to run properly 
-  
+  static: discard validateFkField(fkColumnFromJoinToManyStart, J, M1)
+  static: discard validateFkField(fkColumnFromJoinToManyEnd, J, M2)
+
   const joinTableName = J.table()
   const sqlCondition: string = fmt "{joinTableName}.{fkColumnFromJoinToManyStart} = $1"
   dbConn.select(joinModelEntries, sqlCondition, queryStartEntry.id)

--- a/src/norm/sqlite.nim
+++ b/src/norm/sqlite.nim
@@ -390,8 +390,8 @@ proc selectManyToMany*[M1: Model, J: Model, M2: Model](dbConn; queryStartEntry: 
   ## `fkColumnFromJoinToManyEnd`.
   ## Will not compile if the specified fields on the joinModel do not properly point
   ## to the tables of `queryStartEntry` and `queryEndEntries`.
-  const tmp1 = validateFkField(fkColumnFromJoinToManyStart, J, M1) # 'tmp1' is irrelevant, but the assignment is required for 'validateFkField' to run properly
-  const tmp2 = validateFkField(fkColumnFromJoinToManyEnd, J, M2) # 'tmp2' is irrelevant, but the assignment is required for 'validateFkField' to run properly 
+  static: discard validateFkField(fkColumnFromJoinToManyStart, J, M1) # 'tmp1' is irrelevant, but the assignment is required for 'validateFkField' to run properly
+  static: discard validateFkField(fkColumnFromJoinToManyEnd, J, M2) # 'tmp2' is irrelevant, but the assignment is required for 'validateFkField' to run properly 
   
   const joinTableName = J.table()
   const sqlCondition: string = "$#.$# = ?" % [joinTableName, fkColumnFromJoinToManyStart]


### PR DESCRIPTION
Elegantbeef taught me that there is static discard.
Which is exactly what I wanted, as the validateFkField proc is solely there for its side effects that causes compile time errors if a relationship between 3 types is invalid.

This PR has the benefit of getting rid of various compiler warnings about unused variables (the tmp ones that we get rid of here).