### PR TITLE
enable deepcopy for tests

### DIFF
--- a/tests/config.nims
+++ b/tests/config.nims
@@ -1,3 +1,3 @@
 switch("path", "$projectDir/../src")
 switch("define", "normDebug")
-
+switch("deepcopy", "on")


### PR DESCRIPTION
Hello, the Nim v2 is going to default to orc. For --gc:arc|orc 'deepcopy' support has to be enabled with --deepcopy:on. This option appears since 1.4.0


ref https://github.com/nim-lang/Nim/pull/19972