### PR TITLE
Feature/142 multi many to many query procs

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,10 @@
 -   [t]—test suite improvement
 -   [d]—docs improvement
 
+## 2.5.1 (July 9, 2022)
+- [f] Fixed further points where compile-time assertions created unused variables
+- [f] Fixed `selectOneToMany` and `selectManyToMany` that were introduced in 2.5.1 being unable to deal with FK fields that were Optionals or directly ids.
+
 ## 2.5.0 (July 7, 2022)
 
 - [+] Added `selectOneToMany` proc overload that is able to query multiple many-to-one relationships at once (see [#142](https://github.com/moigagoo/norm/issues/142))

--- a/src/norm/postgres.nim
+++ b/src/norm/postgres.nim
@@ -404,11 +404,13 @@ proc selectOneToMany*[O: Model, M: Model](dbConn; oneEntries: seq[O], relatedEnt
   for entryId in entryIds:
     let id = entryId
     when M.dot(foreignKeyFieldName) is int64:
-        relatedEntries[entryId] = relatedEntriesSeq.filter(target => target.dot(foreignKeyFieldName) == id)
+      relatedEntries[entryId] = relatedEntriesSeq.filter(target => target.dot(foreignKeyFieldName) == id)
     elif M.dot(foreignKeyFieldName) is Option[int64]:
-        relatedEntries[entryId] = relatedEntriesSeq.filter(target => target.dot(foreignKeyFieldName).get() == id)
+      relatedEntries[entryId] = relatedEntriesSeq.filter(target => target.dot(foreignKeyFieldName).get() == id)
+    elif M.dot(foreignKeyFieldName) is Option[O]:
+      relatedEntries[entryId] = relatedEntriesSeq.filter(target => target.dot(foreignKeyFieldName).get().id == id)
     else:
-        relatedEntries[entryId] = relatedEntriesSeq.filter(target => target.dot(foreignKeyFieldName).id == id)
+      relatedEntries[entryId] = relatedEntriesSeq.filter(target => target.dot(foreignKeyFieldName).id == id)
 
 proc selectOneToMany*[O: Model, M: Model](dbConn; oneEntries: seq[O], relatedEntries: var seq[M]) =
   ## A convenience proc. Fetches all entries of multiple "many" side from multiple 

--- a/src/norm/postgres.nim
+++ b/src/norm/postgres.nim
@@ -403,7 +403,12 @@ proc selectOneToMany*[O: Model, M: Model](dbConn; oneEntries: seq[O], relatedEnt
 
   for entryId in entryIds:
     let id = entryId
-    relatedEntries[entryId] = relatedEntriesSeq.filter(target => target.dot(foreignKeyFieldName).id == id)
+    when M.dot(foreignKeyFieldName) is int64:
+        relatedEntries[entryId] = relatedEntriesSeq.filter(target => target.dot(foreignKeyFieldName) == id)
+    elif M.dot(foreignKeyFieldName) is Option[int64]:
+        relatedEntries[entryId] = relatedEntriesSeq.filter(target => target.dot(foreignKeyFieldName).get() == id)
+    else:
+        relatedEntries[entryId] = relatedEntriesSeq.filter(target => target.dot(foreignKeyFieldName).id == id)
 
 proc selectOneToMany*[O: Model, M: Model](dbConn; oneEntries: seq[O], relatedEntries: var seq[M]) =
   ## A convenience proc. Fetches all entries of multiple "many" side from multiple 

--- a/src/norm/postgres.nim
+++ b/src/norm/postgres.nim
@@ -361,7 +361,7 @@ proc selectOneToMany*[O: Model, M: Model](dbConn; oneEntry: O, relatedEntries: v
   ## between the model of `oneEntry` and the model of `relatedEntries`. It is
   ## ensured at compile time that the field specified here is a valid foreign key
   ## field on oneEntry pointing to the table of the `relatedEntries`-model.
-  const _ = validateFkField(foreignKeyFieldName, M, O) # '_' is irrelevant, but the assignment is required for 'validateFkField' to run properly at compileTime
+  static: discard validateFkField(foreignKeyFieldName, M, O) # '_' is irrelevant, but the assignment is required for 'validateFkField' to run properly at compileTime
 
   const manyTableName = M.table()
   const sqlCondition = fmt "{manyTableName}.{foreignKeyFieldName} = $1"
@@ -433,8 +433,8 @@ proc selectManyToMany*[M1: Model, J: Model, M2: Model](dbConn; queryStartEntry: 
   ## `fkColumnFromJoinToManyEnd`.
   ## Will not compile if the specified fields on the joinModel do not properly point
   ## to the tables of `queryStartEntry` and `queryEndEntries`.
-  const tmp1 = validateFkField(fkColumnFromJoinToManyStart, J, M1) # 'tmp1' is irrelevant, but the assignment is required for 'validateFkField' to run properly
-  const tmp2 = validateFkField(fkColumnFromJoinToManyEnd, J, M2) # 'tmp2' is irrelevant, but the assignment is required for 'validateFkField' to run properly 
+  static: discard validateFkField(fkColumnFromJoinToManyStart, J, M1)
+  static: discard validateFkField(fkColumnFromJoinToManyEnd, J, M2)
   
   const joinTableName = J.table()
   const sqlCondition: string = fmt "{joinTableName}.{fkColumnFromJoinToManyStart} = $1"

--- a/src/norm/sqlite.nim
+++ b/src/norm/sqlite.nim
@@ -401,11 +401,13 @@ proc selectOneToMany*[O: Model, M: Model](dbConn; oneEntries: seq[O], relatedEnt
   for entryId in entryIds:
     let id = entryId
     when M.dot(foreignKeyFieldName) is int64:
-        relatedEntries[entryId] = relatedEntriesSeq.filter(target => target.dot(foreignKeyFieldName) == id)
+      relatedEntries[entryId] = relatedEntriesSeq.filter(target => target.dot(foreignKeyFieldName) == id)
     elif M.dot(foreignKeyFieldName) is Option[int64]:
-        relatedEntries[entryId] = relatedEntriesSeq.filter(target => target.dot(foreignKeyFieldName).get() == id)
+      relatedEntries[entryId] = relatedEntriesSeq.filter(target => target.dot(foreignKeyFieldName).get() == id)
+    elif M.dot(foreignKeyFieldName) is Option[O]:
+      relatedEntries[entryId] = relatedEntriesSeq.filter(target => target.dot(foreignKeyFieldName).get().id == id)
     else:
-        relatedEntries[entryId] = relatedEntriesSeq.filter(target => target.dot(foreignKeyFieldName).id == id)
+      relatedEntries[entryId] = relatedEntriesSeq.filter(target => target.dot(foreignKeyFieldName).id == id)
 
 proc selectOneToMany*[O: Model, M: Model](dbConn; oneEntries: seq[O], relatedEntries: var seq[M]) =
   ## A convenience proc. Fetches all entries of multiple "many" side from multiple 

--- a/src/norm/sqlite.nim
+++ b/src/norm/sqlite.nim
@@ -400,7 +400,12 @@ proc selectOneToMany*[O: Model, M: Model](dbConn; oneEntries: seq[O], relatedEnt
 
   for entryId in entryIds:
     let id = entryId
-    relatedEntries[entryId] = relatedEntriesSeq.filter(target => target.dot(foreignKeyFieldName).id == id)
+    when M.dot(foreignKeyFieldName) is int64:
+        relatedEntries[entryId] = relatedEntriesSeq.filter(target => target.dot(foreignKeyFieldName) == id)
+    elif M.dot(foreignKeyFieldName) is Option[int64]:
+        relatedEntries[entryId] = relatedEntriesSeq.filter(target => target.dot(foreignKeyFieldName).get() == id)
+    else:
+        relatedEntries[entryId] = relatedEntriesSeq.filter(target => target.dot(foreignKeyFieldName).id == id)
 
 proc selectOneToMany*[O: Model, M: Model](dbConn; oneEntries: seq[O], relatedEntries: var seq[M]) =
   ## A convenience proc. Fetches all entries of multiple "many" side from multiple 

--- a/src/norm/sqlite.nim
+++ b/src/norm/sqlite.nim
@@ -357,7 +357,7 @@ proc selectOneToMany*[O: Model, M: Model](dbConn; oneEntry: O, relatedEntries: v
   ## puts them into `relatedEntries`. It is ensured at compile time that the 
   ## field specified here is a valid foreign key field on oneEntry pointing to 
   ## the table of the `relatedEntries`-model.
-  const _ = validateFkField(foreignKeyFieldName, M, O) # '_' is irrelevant, but the assignment is required for 'validateFkField' to run properly
+  static: discard validateFkField(foreignKeyFieldName, M, O) # '_' is irrelevant, but the assignment is required for 'validateFkField' to run properly
 
   const manyTableName = M.table()
   const sqlCondition = "$#.$# = ?" % [manyTableName, foreignKeyFieldName]
@@ -435,8 +435,8 @@ proc selectManyToMany*[M1: Model, J: Model, M2: Model](dbConn; queryStartEntry: 
   ## `fkColumnFromJoinToManyEnd`.
   ## Will not compile if the specified fields on the joinModel do not properly point
   ## to the tables of `queryStartEntry` and `queryEndEntries`.
-  const tmp1 = validateFkField(fkColumnFromJoinToManyStart, J, M1) # 'tmp1' is irrelevant, but the assignment is required for 'validateFkField' to run properly
-  const tmp2 = validateFkField(fkColumnFromJoinToManyEnd, J, M2) # 'tmp2' is irrelevant, but the assignment is required for 'validateFkField' to run properly 
+  static: discard validateFkField(fkColumnFromJoinToManyStart, J, M1)
+  static: discard validateFkField(fkColumnFromJoinToManyEnd, J, M2)
   
   const joinTableName = J.table()
   const sqlCondition: string = "$#.$# = ?" % [joinTableName, fkColumnFromJoinToManyStart]


### PR DESCRIPTION
There were 2 issues in my new feature:
1) There were still some variable assignments instead of using static discard
2) If you were using `selectOneToMany` and the "many"-model had the FK field as optional or just annotated via fk pragma, the proc couldn't deal with it. Similarly, `selectManyToMany` could not deal with the joinModel having an Option[Many-Model] type. (It can't deal with int64 or Option[int64] types by design since the goal is to extract the actual model from the joinModel field).

This PR should fix that. Changelog adjustments are already included. Tests all pass 