### PR TITLE
Escape column name

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,9 @@
 -   [t]—test suite improvement
 -   [d]—docs improvement
 
+## 2.5.1 (July 19, 2022)
+
+- [f] Usage of SQL keywords as field names is now possible by quoting them in the resulting query.
 
 ## 2.5.0 (July 8, 2022)
 

--- a/norm.nimble
+++ b/norm.nimble
@@ -1,6 +1,6 @@
 # Package
 
-version       = "2.5.0"
+version       = "2.5.1"
 author        = "Constantine Molchanov"
 description   = "Nim ORM for SQLite and PostgreSQL."
 license       = "MIT"

--- a/norm.nimble
+++ b/norm.nimble
@@ -1,6 +1,6 @@
 # Package
 
-version       = "2.5.1"
+version       = "2.5.0"
 author        = "Constantine Molchanov"
 description   = "Nim ORM for SQLite and PostgreSQL."
 license       = "MIT"

--- a/src/norm/model.nim
+++ b/src/norm/model.nim
@@ -44,7 +44,7 @@ func table*(T: typedesc[Model]): string =
 func col*(T: typedesc[Model], fld: string): string =
   ## Get column name for a `Model`_ field, which is just the field name.
 
-  fld
+  fld.escape
 
 func col*[T: Model](obj: T, fld: string): string =
   ## Get column name for a `Model`_ instance field.

--- a/src/norm/model.nim
+++ b/src/norm/model.nim
@@ -44,7 +44,7 @@ func table*(T: typedesc[Model]): string =
 func col*(T: typedesc[Model], fld: string): string =
   ## Get column name for a `Model`_ field, which is just the field name.
 
-  fld.escape
+  "\"" & fld & "\""
 
 func col*[T: Model](obj: T, fld: string): string =
   ## Get column name for a `Model`_ instance field.

--- a/tests/common/tmodel.nim
+++ b/tests/common/tmodel.nim
@@ -16,26 +16,26 @@ suite "Getting table and columns from Model":
       pet = newPet("cat", toy)
       person = newPerson("Alice", pet)
 
-    check person.col("name") == "name"
-    check pet.col("species") == "species"
+    check person.col("name") == "\"name\""
+    check pet.col("species") == "\"species\""
 
-    check person.cols == @["name", "pet"]
-    check person.cols(force = true) == @["name", "pet", "id"]
+    check person.cols == @["\"name\"", "\"pet\""]
+    check person.cols(force = true) == @["\"name\"", "\"pet\"", "\"id\""]
 
-    check person.fCol("name") == """"Person".name"""
-    check pet.fCol("species") == """"Pet".species"""
+    check person.fCol("name") == """"Person"."name""""
+    check pet.fCol("species") == """"Pet"."species""""
 
     check person.rfCols == @[
-      """"Person".name""",
-      """"Person".pet""",
-      """"pet".species""",
-      """"pet".favToy""",
-      """"pet_favToy".price""",
-      """"pet_favToy".id""",
-      """"pet".id""",
-      """"Person".id"""
+      """"Person"."name"""",
+      """"Person"."pet"""",
+      """"pet"."species"""",
+      """"pet"."favToy"""",
+      """"pet_favToy"."price"""",
+      """"pet_favToy"."id"""",
+      """"pet"."id"""",
+      """"Person"."id""""
     ]
-    check toy.rfCols == @[""""Toy".price""", """"Toy".id"""]
+    check toy.rfCols == @[""""Toy"."price"""", """"Toy"."id""""]
 
   test "Join groups":
     let
@@ -44,8 +44,8 @@ suite "Getting table and columns from Model":
       person = newPerson("Alice", pet)
 
     check person.joinGroups == @[
-      (""""Pet"""", """"pet"""", """"Person".pet""", """"pet".id"""),
-      (""""Toy"""", """"pet_favToy"""", """"pet".favToy""", """"pet_favToy".id""")
+      (""""Pet"""", """"pet"""", """"Person"."pet"""", """"pet"."id""""),
+      (""""Toy"""", """"pet_favToy"""", """"pet"."favToy"""", """"pet_favToy"."id"""")
     ]
 
   test "When related model has field with the type of the given model, expect name of that field as a string":


### PR DESCRIPTION
This is a fix for fields that match SQL keywords to cause syntax error in the query.

For example:
```nim
import std / options

import norm / [model, sqlite]

type
  User* = ref object of Model
    email*: string
    group*: int

func newUser*(email = ""): User =
  User(email: email, group: 0)

let dbConn* = open("test.db", "", "", "")
dbConn.createTables(newUser())
```
Will cause `Error: unhandled exception: near "group": syntax error [DbError]` as `group` matches an SQL keyword.
However it is possible to create such fields delimiting them with quotes:
```sql
CREATE TABLE "User"(
  "email" TEXT NOT NULL,
  "group" INTEGER NOT NULL,
  "id" INTEGER NOT NULL PRIMARY KEY
)
```
So this fix uses `strutils.escape` proc to achieve that, though not sure if its a proper way to do this...