### PR TITLE
Removed unnecessary variable assignment

### DIFF
--- a/src/norm/model.nim
+++ b/src/norm/model.nim
@@ -193,7 +193,7 @@ proc validateJoinModelFkField*[S, T: Model](fkFieldName: static string, joinMode
   ## `target` model. Ensures that the type in the field `fkFieldName` is `target` 
   ## If it isn't the code won't compile as that Model type is required for a useful
   ## Many-To-Many query.
-  let tmp = validateFkField(fkFieldName, joinModel, target)
+  discard validateFkField(fkFieldName, joinModel, target)
   
   for joinFieldName, joinFieldValue in joinModel()[].fieldPairs:
     when joinFieldName == fkFieldName:


### PR DESCRIPTION
This is a minor beautification thing.
I should've caught that one with the last 2 PRs about this, but apparently I still missed this one.
Doesn't change any logic, basically just allows people to get rid of an unnecessary warning.