### PR TITLE
Feature/#133 add public from row

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -10,7 +10,8 @@
 ## 2.5.2 (WIP)
 
 - [r] Logging: refactored `log` module to not trigger warnings when `normDebug` is not defined.
-
+- [r] Slightly changed how objects are being parsed, leading to a small performance increase
+- [+] Added `rawSelect` proc, which allows you execute raw SQL and have the output be parsed into a custom object-type
 
 ## 2.5.1 (July 20, 2022)
 - [+] Added `uniqueGroup` pragma to provide UNIQUE constraint on multiple columns (see [#136](https://github.com/moigagoo/norm/issues/136)).

--- a/src/norm/postgres.nim
+++ b/src/norm/postgres.nim
@@ -242,6 +242,7 @@ proc rawSelect*[T: ref object](dbConn; qry: string, obj: var T, params: varargs[
 
   ``qry`` is the raw sql query whose contents are to be parsed into obj.
   The columns on ``qry`` must be in the same order as the fields on ``obj``.
+  Table names must be written surrounded by quotation marks and are case sensititve.
   ]##
   let row = dbConn.getRow(sql qry, params)
   
@@ -257,6 +258,7 @@ proc rawSelect*[T: ref object](dbConn; qry: string, objs: var seq[T], params: va
 
   The columns on ``qry`` must be in the same order as the fields on ``objs``.
   ``objs`` must have at least one item.
+  Table names must be written surrounded by quotation marks and are case sensititve.
   ]##
   let rows = dbConn.getAllRows(sql qry, params)
 

--- a/src/norm/postgres.nim
+++ b/src/norm/postgres.nim
@@ -243,7 +243,7 @@ proc rawSelect*[T: ref object](dbConn; qry: string, obj: var T, params: varargs[
   ``qry`` is the raw sql query whose contents are to be parsed into obj.
   The columns on ``qry`` must be in the same order as the fields on ``obj``.
   ]##
-  let row = dbConn.getAllRows(sql qry, params)
+  let row = dbConn.getRow(sql qry, params)
   
   if row.isNone:
     raise newException(NotFoundError, "Record not found")

--- a/src/norm/private/postgres/rowutils.nim
+++ b/src/norm/private/postgres/rowutils.nim
@@ -14,40 +14,54 @@ when (NimMajor, NimMinor) <= (1, 6):
 else:
   import std/macros
 
-proc fromRowPos[T: Model](obj: var T, row: Row, pos: var Natural, skip = false) =
+
+func isContainer*[T](val: typedesc[T]): bool {.compileTime.} = T is ref object
+func isContainer*[T](val: T): bool {.compileTime.} = T is ref object
+func isContainer*[T](val: typedesc[Option[T]]): bool {.compileTime.} = T is ref object  
+func isContainer*[T](val: Option[T]): bool {.compileTime.} = T is ref object  
+
+func toOptional*[T: ref object](val: T): Option[T] = some val
+func toOptional*[T: ref object](val: Option[T]): Option[T] = val
+func isEmptyColumn(row: Row, index: int): bool = row[index].kind == dvkNull
+
+
+## This does the actual heavy lifting for parsing
+proc fromRowPos[T: ref object](obj: var T, row: Row, pos: var Natural, skip: static bool = false) =
   ##[ Convert ``ndb.sqlite.Row`` instance into `Model`_ instance, from a given position.
 
   This is a helper proc to convert to `Model`_ instances that have fields of the same type.
   ]##
 
-  for fld, val in obj[].fieldPairs:
-    if val.isModel:                                 ## If we're dealing with a ``Model`` field
-      if val.model.isSome:                          ## and it's either a ``some Model`` or ``Model``
-        var subMod = get val.model                  ## then we try to populate it with the next ``row`` values.
+  for fld, dummyVal in T()[].fieldPairs:
+    when isContainer(typeof(dummyVal)):                 ## If we're dealing with a ``Model`` field
+      if dot(obj, fld).toOptional().isSome:             ## and it's either a ``some Model`` or ``Model``
+        var subMod = dot(obj, fld).toOptional().get()   ## then we try to populate it with the next ``row`` values.
 
-        if row[pos].kind == dvkNull:                ## If we have a ``NULL`` at this point, we return an empty ``Model``:
-          when val is Option:                       ## ``val`` is guaranteed to be either ``Model`` or an ``Option[Model]`` at this point,
-            when get(val) is Model:                 ## and the fact that we got a ``NULL`` tells us it's an ``Option[Model]``,
-              val = none typeof(subMod)             ## so we return a ``none Model``.
+        if row.isEmptyColumn(pos):                      ## If we have a ``NULL`` at this point, we return an empty ``Model``:
+          when typeof(dummyVal) is Option:              ## ``val`` is guaranteed to be either ``Model`` or an ``Option[Model]`` at this point,
+            when isContainer(dummyVal): 
+              dot(obj, fld) = none typeof(subMod)       ## and the fact that we got a ``NULL`` tells us it's an ``Option[Model]``,
 
           inc pos
-          subMod.fromRowPos(row, pos, skip = true)  ## Then we skip all the ``row`` values that should've gone into this submodel.
+          subMod.fromRowPos(row, pos, skip = true)      ## Then we skip all the ``row`` values that should've gone into this submodel.
 
-        else:                                       ## If ``row[pos]`` is not a ``NULL``,
-          inc pos                                   ##
-          subMod.fromRowPos(row, pos)               ## we actually populate the submodel.
+        else:                                           ## If ``row[pos]`` is not a ``NULL``,
+          inc pos                                       ##
+          subMod.fromRowPos(row, pos)                   ## we actually populate the submodel.
 
-      else:                                         ## If the field is a ``none Model``,
-        inc pos                                     ## don't bother trying to populate it at all.
-
-    elif not skip:                                  ## If we're dealing with an "ordinary" field,
-      val = row[pos].to(typeof(val))                ## just convert it.
-      inc pos
-
+      else:                                             ## If the field is a ``none Model``,
+        inc pos                                         ## don't bother trying to populate it at all.
+                                          
     else:
-      inc pos
+      when not skip:                                    ## If we're dealing with an "ordinary" field,
+        dot(obj, fld) = row[pos].to(typeof(dummyVal))   ## just convert it.
+        inc pos
 
-proc fromRow*[T: Model](obj: var T, row: Row) =
+      else:
+        inc pos
+  
+
+proc fromRow*[T: ref object](obj: var T, row: Row) =
   ##[ Populate `Model`_ instance from ``ndb.postgres.Row`` instance.
 
   Nested `Model`_ fields are populated from the same ``ndb.postgres.Row`` instance.

--- a/src/norm/private/sqlite/rowutils.nim
+++ b/src/norm/private/sqlite/rowutils.nim
@@ -14,40 +14,52 @@ when (NimMajor, NimMinor) <= (1, 6):
 else:
   import std/macros
 
-proc fromRowPos[T: Model](obj: var T, row: Row, pos: var Natural, skip = false) =
+func isContainer*[T](val: typedesc[T]): bool {.compileTime.} = T is ref object
+func isContainer*[T](val: T): bool {.compileTime.} = T is ref object
+func isContainer*[T](val: typedesc[Option[T]]): bool {.compileTime.} = T is ref object  
+func isContainer*[T](val: Option[T]): bool {.compileTime.} = T is ref object  
+
+func toOptional*[T: ref object](val: T): Option[T] = some val
+func toOptional*[T: ref object](val: Option[T]): Option[T] = val
+func isEmptyColumn(row: Row, index: int): bool = row[index].kind == dvkNull
+
+
+## This does the actual heavy lifting for parsing
+proc fromRowPos[T: ref object](obj: var T, row: Row, pos: var Natural, skip: static bool = false) =
   ##[ Convert ``ndb.sqlite.Row`` instance into `Model`_ instance, from a given position.
 
   This is a helper proc to convert to `Model`_ instances that have fields of the same type.
   ]##
 
-  for fld, val in obj[].fieldPairs:
-    if val.isModel:                                 ## If we're dealing with a ``Model`` field
-      if val.model.isSome:                          ## and it's either a ``some Model`` or ``Model``
-        var subMod = get val.model                  ## then we try to populate it with the next ``row`` values.
+  for fld, dummyVal in T()[].fieldPairs:
+    when isContainer(typeof(dummyVal)):                 ## If we're dealing with a ``Model`` field
+      if dot(obj, fld).toOptional().isSome:             ## and it's either a ``some Model`` or ``Model``
+        var subMod = dot(obj, fld).toOptional().get()   ## then we try to populate it with the next ``row`` values.
 
-        if row[pos].kind == dvkNull:                ## If we have a ``NULL`` at this point, we return an empty ``Model``:
-          when val is Option:                       ## ``val`` is guaranteed to be either ``Model`` or an ``Option[Model]`` at this point,
-            when get(val) is Model:                 ## and the fact that we got a ``NULL`` tells us it's an ``Option[Model]``,
-              val = none typeof(subMod)             ## so we return a ``none Model``.
+        if row.isEmptyColumn(pos):                      ## If we have a ``NULL`` at this point, we return an empty ``Model``:
+          when typeof(dummyVal) is Option:              ## ``val`` is guaranteed to be either ``Model`` or an ``Option[Model]`` at this point,
+            when isContainer(dummyVal): 
+              dot(obj, fld) = none typeof(subMod)       ## and the fact that we got a ``NULL`` tells us it's an ``Option[Model]``,
 
           inc pos
-          subMod.fromRowPos(row, pos, skip = true)  ## Then we skip all the ``row`` values that should've gone into this submodel.
+          subMod.fromRowPos(row, pos, skip = true)      ## Then we skip all the ``row`` values that should've gone into this submodel.
 
-        else:                                       ## If ``row[pos]`` is not a ``NULL``,
-          inc pos                                   ##
-          subMod.fromRowPos(row, pos)               ## we actually populate the submodel.
+        else:                                           ## If ``row[pos]`` is not a ``NULL``,
+          inc pos                                       ##
+          subMod.fromRowPos(row, pos)                   ## we actually populate the submodel.
 
-      else:                                         ## If the field is a ``none Model``,
-        inc pos                                     ## don't bother trying to populate it at all.
-
-    elif not skip:                                  ## If we're dealing with an "ordinary" field,
-      val = row[pos].to(typeof(val))                ## just convert it.
-      inc pos
-
+      else:                                             ## If the field is a ``none Model``,
+        inc pos                                         ## don't bother trying to populate it at all.
+                                          
     else:
-      inc pos
+      when not skip:                                    ## If we're dealing with an "ordinary" field,
+        dot(obj, fld) = row[pos].to(typeof(dummyVal))   ## just convert it.
+        inc pos
 
-proc fromRow*[T: Model](obj: var T, row: Row) =
+      else:
+        inc pos
+  
+proc fromRow*[T: ref object](obj: var T, row: Row) =
   ##[ Populate `Model`_ instance from ``ndb.sqlite.Row`` instance.
 
   Nested `Model`_ fields are populated from the same ``ndb.sqlite.Row`` instance.

--- a/src/norm/private/sqlite/rowutils.nim
+++ b/src/norm/private/sqlite/rowutils.nim
@@ -6,6 +6,7 @@ import ndb/sqlite
 
 import dbtypes
 import ../dot
+import ../utils
 import ../../model
 import ../../pragmas
 
@@ -14,15 +15,9 @@ when (NimMajor, NimMinor) <= (1, 6):
 else:
   import std/macros
 
-func isContainer*[T](val: typedesc[T]): bool {.compileTime.} = T is ref object
-func isContainer*[T](val: T): bool {.compileTime.} = T is ref object
-func isContainer*[T](val: typedesc[Option[T]]): bool {.compileTime.} = T is ref object  
-func isContainer*[T](val: Option[T]): bool {.compileTime.} = T is ref object  
-
-func toOptional*[T: ref object](val: T): Option[T] = some val
-func toOptional*[T: ref object](val: Option[T]): Option[T] = val
-func isEmptyColumn(row: Row, index: int): bool = row[index].kind == dvkNull
-
+func isEmptyColumn*(row: Row, index: int): bool =
+  ## Checks whether the column at a given index is empty
+  row[index].kind == dvkNull
 
 ## This does the actual heavy lifting for parsing
 proc fromRowPos[T: ref object](obj: var T, row: Row, pos: var Natural, skip: static bool = false) =
@@ -32,13 +27,13 @@ proc fromRowPos[T: ref object](obj: var T, row: Row, pos: var Natural, skip: sta
   ]##
 
   for fld, dummyVal in T()[].fieldPairs:
-    when isContainer(typeof(dummyVal)):                 ## If we're dealing with a ``Model`` field
+    when isRefObject(typeof(dummyVal)):                 ## If we're dealing with a ``Model`` field
       if dot(obj, fld).toOptional().isSome:             ## and it's either a ``some Model`` or ``Model``
         var subMod = dot(obj, fld).toOptional().get()   ## then we try to populate it with the next ``row`` values.
 
         if row.isEmptyColumn(pos):                      ## If we have a ``NULL`` at this point, we return an empty ``Model``:
           when typeof(dummyVal) is Option:              ## ``val`` is guaranteed to be either ``Model`` or an ``Option[Model]`` at this point,
-            when isContainer(dummyVal): 
+            when isRefObject(dummyVal):
               dot(obj, fld) = none typeof(subMod)       ## and the fact that we got a ``NULL`` tells us it's an ``Option[Model]``,
 
           inc pos

--- a/src/norm/private/utils.nim
+++ b/src/norm/private/utils.nim
@@ -1,0 +1,25 @@
+import std/options
+
+func isRefObject*[T](val: typedesc[T]): bool {.compileTime.} =
+  ## Checks if a given type is of type ref object
+  T is ref object
+
+func isRefObject*[T](val: T): bool {.compileTime.} =
+  ## Checks if a given variable is of type ref object
+  T is ref object
+
+func isRefObject*[T](val: typedesc[Option[T]]): bool {.compileTime.} =
+  ## Checks if the inner type of an given optional type is a ref object
+  T is ref object
+
+func isRefObject*[T](val: Option[T]): bool {.compileTime.} =
+  ## Checks if the inner type of the optional variable is a ref object
+  T is ref object
+
+func toOptional*[T: ref object](val: T): Option[T] =
+  ## Converts non optional type to optional type
+  some val
+
+func toOptional*[T: ref object](val: Option[T]): Option[T] =
+  ## Convert optional type to optional type, doing effectively nothing
+  val

--- a/src/norm/sqlite.nim
+++ b/src/norm/sqlite.nim
@@ -239,6 +239,38 @@ proc selectAll*[T: Model](dbConn; objs: var seq[T]) =
 
   dbConn.select(objs, "1")
 
+proc rawSelect*[T: ref object](dbConn; qry: string, obj: var T, params: varargs[DbValue, dbValue]) {.raises: {ValueError, DbError, LoggingError}.} =
+  ##[ Populate a ref object instance ``obj`` and its ref object fields from DB.
+
+  ``qry`` is the raw sql query whose contents are to be parsed into obj.
+  The columns on ``qry`` must be in the same order as the fields on ``obj``.
+  ]##
+  let row = dbConn.getAllRows(sql qry, params)
+  
+  if row.isNone:
+    raise newException(NotFoundError, "Record not found")
+
+  obj.fromRow(get row)
+
+proc rawSelect*[T: ref object](dbConn; qry: string, objs: var seq[T], params: varargs[DbValue, dbValue]) {.raises: {ValueError, DbError, LoggingError}.} =
+  ##[ Populate a sequence of ref object instances from DB.
+
+  ``qry`` is the raw sql query whose contents are to be parsed into ``objs``.
+
+  The columns on ``qry`` must be in the same order as the fields on ``objs``.
+  ``objs`` must have at least one item.
+  ]##
+  let rows = dbConn.getAllRows(sql qry, params)
+
+  if objs.len > rows.len:
+    objs.setLen(rows.len)
+
+  for _ in 1..(rows.len - objs.len):
+    objs.add deepCopy(objs[0])
+
+  for i, row in rows:
+    objs[i].fromRow(row)
+
 proc count*(dbConn; T: typedesc[Model], col = "*", dist = false, cond = "1", params: varargs[DbValue, dbValue]): int64 =
   ##[ Count rows matching condition without fetching them.
 

--- a/src/norm/sqlite.nim
+++ b/src/norm/sqlite.nim
@@ -245,7 +245,7 @@ proc rawSelect*[T: ref object](dbConn; qry: string, obj: var T, params: varargs[
   ``qry`` is the raw sql query whose contents are to be parsed into obj.
   The columns on ``qry`` must be in the same order as the fields on ``obj``.
   ]##
-  let row = dbConn.getAllRows(sql qry, params)
+  let row = dbConn.getRow(sql qry, params)
   
   if row.isNone:
     raise newException(NotFoundError, "Record not found")

--- a/tests/postgres/trawselect.nim
+++ b/tests/postgres/trawselect.nim
@@ -1,0 +1,108 @@
+import std/[unittest, with, os, sugar, options, logging, strutils]
+
+import norm/[model, postgres]
+
+import ../models
+
+
+const
+  dbHost = "postgres"
+  dbUser = "postgres"
+  dbPassword = "postgres"
+  dbDatabase = "postgres"
+
+proc resetDb =
+  let dbConn = open(dbHost, dbUser, dbPassword, "template1")
+  dbConn.exec(sql "DROP DATABASE IF EXISTS $#" % dbDatabase)
+  dbConn.exec(sql "CREATE DATABASE $#" % dbDatabase)
+  close dbConn
+
+
+addHandler(newConsoleLogger(levelThreshold = lvlDebug))
+
+suite "Testing rawSelect proc":
+  setup:
+    resetDb()
+    let dbConn = open(dbHost, dbUser, dbPassword, dbDatabase)
+
+    var
+      alice = newPerson("Alice", none Pet)
+      bob = newPerson("Bob", none Pet)
+      jeff = newPerson("Jeff", none Pet)
+
+      someDoctor = newDoctor("Vet1")
+
+      visit1 = newDoctorVisit(alice, someDoctor)
+      visit2 = newDoctorVisit(bob, someDoctor)
+
+      boneToy = newToy()
+      ballToy = newToy()
+
+      spot = newPlayfulPet("spot", boneToy, ballToy)
+
+    dbConn.createTables(newPerson())
+    dbConn.createTables(newDoctor())
+    dbConn.createTables(newDoctorVisit())
+    dbConn.createTables(newToy())
+    dbConn.createTables(newPlayfulPet())
+    discard @[alice, bob, jeff].dup:
+      dbConn.insert
+
+    discard @[someDoctor].dup:
+      dbConn.insert
+
+    discard @[visit1, visit2].dup:
+      dbConn.insert
+
+    discard @[boneToy, ballToy].dup:
+      dbConn.insert
+
+    discard @[spot].dup:
+      dbConn.insert
+
+
+  teardown:
+    close dbConn
+    resetDb()
+
+
+  test "rawSelect single entry":
+    type MyDoc = ref object
+      name: string
+
+    let sql = """SELECT name FROM "Doctor" WHERE id = $1"""
+    var mydoc = MyDoc()
+    dbConn.rawSelect(sql, mydoc, someDoctor.id)
+
+    check mydoc.name == "Vet1"
+
+  test "rawSelect multiple entries":
+    type MyPerson = ref object
+      name: string
+
+    let sql = """SELECT name FROM "Person" ORDER BY id"""
+    var myPeople = @[MyPerson()]
+    dbConn.rawSelect(sql, myPeople)
+
+    check myPeople.len() == 3
+    check myPeople[0].name == "Alice"
+    check myPeople[1].name == "Bob"
+    check myPeople[2].name == "Jeff"
+
+  test "rawSelect with Model":
+    let sql = """SELECT name, NULL, NULL, NULL, NULL, NULL, NULL, id FROM "Person""""
+    var myPeople = @[newPerson()]
+    dbConn.rawSelect(sql, myPeople)
+
+    check myPeople.len() == 3
+    check myPeople[0].name == "Alice"
+    check myPeople[0].pet.isNone()
+    check myPeople[0].id == 1
+
+    check myPeople[1].name == "Bob"
+    check myPeople[1].pet.isNone()
+    check myPeople[1].id == 2
+
+    check myPeople[2].name == "Jeff"
+    check myPeople[2].pet.isNone()
+    check myPeople[2].id == 3

--- a/tests/postgres/trawselect.nim
+++ b/tests/postgres/trawselect.nim
@@ -1,4 +1,4 @@
-import std/[unittest, with, os, sugar, options, logging, strutils]
+import std/[unittest, with, os, sugar, options, strutils]
 
 import norm/[model, postgres]
 
@@ -16,9 +16,6 @@ proc resetDb =
   dbConn.exec(sql "DROP DATABASE IF EXISTS $#" % dbDatabase)
   dbConn.exec(sql "CREATE DATABASE $#" % dbDatabase)
   close dbConn
-
-
-addHandler(newConsoleLogger(levelThreshold = lvlDebug))
 
 suite "Testing rawSelect proc":
   setup:

--- a/tests/sqlite/trawselect.nim
+++ b/tests/sqlite/trawselect.nim
@@ -1,4 +1,4 @@
-import std/[unittest, with, os, sugar, options, logging]
+import std/[unittest, with, os, sugar, options]
 
 import norm/[model, sqlite]
 
@@ -6,8 +6,6 @@ import ../models
 
 
 const dbFile = "test.db"
-
-addHandler(newConsoleLogger(levelThreshold = lvlDebug))
 
 suite "Testing rawSelect proc":
   setup:

--- a/tests/sqlite/trawselect.nim
+++ b/tests/sqlite/trawselect.nim
@@ -1,0 +1,97 @@
+import std/[unittest, with, os, sugar, options, logging]
+
+import norm/[model, sqlite]
+
+import ../models
+
+
+const dbFile = "test.db"
+
+addHandler(newConsoleLogger(levelThreshold = lvlDebug))
+
+suite "Testing rawSelect proc":
+  setup:
+    removeFile dbFile
+
+    let dbConn = open(dbFile, "", "", "")
+
+    var
+      alice = newPerson("Alice", none Pet)
+      bob = newPerson("Bob", none Pet)
+      jeff = newPerson("Jeff", none Pet)
+
+      someDoctor = newDoctor("Vet1")
+
+      visit1 = newDoctorVisit(alice, someDoctor)
+      visit2 = newDoctorVisit(bob, someDoctor)
+
+      boneToy = newToy()
+      ballToy = newToy()
+
+      spot = newPlayfulPet("spot", boneToy, ballToy)
+
+    dbConn.createTables(newPerson())
+    dbConn.createTables(newDoctor())
+    dbConn.createTables(newDoctorVisit())
+    dbConn.createTables(newToy())
+    dbConn.createTables(newPlayfulPet())
+    discard @[alice, bob, jeff].dup:
+      dbConn.insert
+
+    discard @[someDoctor].dup:
+      dbConn.insert
+
+    discard @[visit1, visit2].dup:
+      dbConn.insert
+
+    discard @[boneToy, ballToy].dup:
+      dbConn.insert
+
+    discard @[spot].dup:
+      dbConn.insert
+
+
+  teardown:
+    close dbConn
+    removeFile dbFile
+
+  test "rawSelect single entry":
+    type MyDoc = ref object
+      name: string
+
+    let sql = "SELECT name FROM Doctor WHERE id = ?"
+    var mydoc = MyDoc()
+    dbConn.rawSelect(sql, mydoc, someDoctor.id)
+
+    check mydoc.name == "Vet1"
+
+  test "rawSelect multiple entries":
+    type MyPerson = ref object
+      name: string
+
+    let sql = "SELECT name FROM Person ORDER BY id"
+    var myPeople = @[MyPerson()]
+    dbConn.rawSelect(sql, myPeople)
+
+    check myPeople.len() == 3
+    check myPeople[0].name == "Alice"
+    check myPeople[1].name == "Bob"
+    check myPeople[2].name == "Jeff"
+
+  test "rawSelect with Model":
+    let sql = "SELECT name, NULL, NULL, NULL, NULL, NULL, NULL, id FROM Person"
+    var myPeople = @[newPerson()]
+    dbConn.rawSelect(sql, myPeople)
+
+    check myPeople.len() == 3
+    check myPeople[0].name == "Alice"
+    check myPeople[0].pet.isNone()
+    check myPeople[0].id == 1
+
+    check myPeople[1].name == "Bob"
+    check myPeople[1].pet.isNone()
+    check myPeople[1].id == 2
+
+    check myPeople[2].name == "Jeff"
+    check myPeople[2].pet.isNone()
+    check myPeople[2].id == 3


### PR DESCRIPTION
This proc adds the feature requested by #133 :
A way to interact with the database with arbitrary SQL, yet still benefit from norms incredibly useful parsing of Row to objects, just this time it allows for arbitrary object types instead of using models.

This has the following benefits:
- It becomes possible to interact with views which do not have an `id` column, as the user can define their own types for interacting with the view
- It becomes possible to use norm for executing arbitrary complex SQL such as recursive queries, which was not possible before

The specific procs that allows this are:
- A modification of `fromRowPos` and `fromRow` which now can deal with *any ref object*  as opposed to only `Model` types
- `rawSelect` procs that make use of that and allow the user to pass non-Model ref object and a full SQL query to execute

**A small side-benefit:**
I observed around a 10% speed-up for my limited test-cases when executing the "new" version of `fromRowPos`. The reason for this speed-up is that some computation has been moved to compile-time instead of runtime.

**Things that would still need to be done:**
- General review + Approval that this feature is wanted
- ~~Figure out in which module procs such as `isContainer`, `toOptional` and `isEmptyColumn` should be stored, as `rowutils` does not feel like the appropriate place for these~~ (I've decided to put them into a shared `utils.nim` module in private)
- ~~Figure out actually decent names for `isContainer` and `toOptional`. These names are (in my mind) only placeholders since I couldn't think of a better name for now. They are more "open" alternatives to `isModel` and `model`. With the new context of using ref object instead of Model however `isRefObject` and `refObject` as names seemed confusing to me.~~ (I've decided to go with `toOptional` and `isRefObject`)
- ~~Write tests for the `rawSelect` procs (and maybe the modified `fromRowPos` proc)  ( @moigagoo I would proceed with this point and the ones below once we ironed out the other ones)~~ (Basic tests are written. The details of the parsing into ref object do not need to be tested - the parsing from object to model already does that) 
- ~~Add changelog changes~~ (DONE)
- Add nimibook docs