### PR TITLE
Escape column name

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,9 @@
 -   [t]—test suite improvement
 -   [d]—docs improvement
 
+## 2.5.1 (July 19, 2022)
+
+- [f] Usage of SQL keywords as field names is now possible by quoting them in the resulting query.
 
 ## 2.5.0 (July 8, 2022)
 

--- a/norm.nimble
+++ b/norm.nimble
@@ -1,6 +1,6 @@
 # Package
 
-version       = "2.5.0"
+version       = "2.5.1"
 author        = "Constantine Molchanov"
 description   = "Nim ORM for SQLite and PostgreSQL."
 license       = "MIT"

--- a/norm.nimble
+++ b/norm.nimble
@@ -1,6 +1,6 @@
 # Package
 
-version       = "2.5.1"
+version       = "2.5.0"
 author        = "Constantine Molchanov"
 description   = "Nim ORM for SQLite and PostgreSQL."
 license       = "MIT"

--- a/src/norm/model.nim
+++ b/src/norm/model.nim
@@ -44,7 +44,7 @@ func table*(T: typedesc[Model]): string =
 func col*(T: typedesc[Model], fld: string): string =
   ## Get column name for a `Model`_ field, which is just the field name.
 
-  fld
+  fld.escape
 
 func col*[T: Model](obj: T, fld: string): string =
   ## Get column name for a `Model`_ instance field.

--- a/src/norm/model.nim
+++ b/src/norm/model.nim
@@ -44,7 +44,7 @@ func table*(T: typedesc[Model]): string =
 func col*(T: typedesc[Model], fld: string): string =
   ## Get column name for a `Model`_ field, which is just the field name.
 
-  fld.escape
+  "\"" & fld & "\""
 
 func col*[T: Model](obj: T, fld: string): string =
   ## Get column name for a `Model`_ instance field.

--- a/src/norm/postgres.nim
+++ b/src/norm/postgres.nim
@@ -101,7 +101,7 @@ proc createTables*[T: Model](dbConn; obj: T) =
       colShmParts.add "UNIQUE"
 
     if val.isModel:
-      var fkGroup = """FOREIGN KEY("$#") REFERENCES $#($#)""" %
+      var fkGroup = """FOREIGN KEY($#) REFERENCES $#($#)""" %
         [obj.col(fld), typeof(get val.model).table, typeof(get val.model).col("id")]
 
       when obj.dot(fld).hasCustomPragma(onDelete):

--- a/src/norm/postgres.nim
+++ b/src/norm/postgres.nim
@@ -101,7 +101,7 @@ proc createTables*[T: Model](dbConn; obj: T) =
       colShmParts.add "UNIQUE"
 
     if val.isModel:
-      var fkGroup = "FOREIGN KEY($#) REFERENCES $#($#)" %
+      var fkGroup = """FOREIGN KEY("$#") REFERENCES $#($#)""" %
         [obj.col(fld), typeof(get val.model).table, typeof(get val.model).col("id")]
 
       when obj.dot(fld).hasCustomPragma(onDelete):
@@ -120,9 +120,9 @@ proc createTables*[T: Model](dbConn; obj: T) =
           const selfTableName = '"' & T.getCustomPragmaVal(tableName) & '"'
         else:
           const selfTableName = '"' & $T & '"'
-        fkGroups.add "FOREIGN KEY ($#) REFERENCES $#(id)" % [fld, selfTableName]
+        fkGroups.add """FOREIGN KEY ("$#") REFERENCES $#(id)""" % [fld, selfTableName]
       else:
-        fkGroups.add "FOREIGN KEY ($#) REFERENCES $#(id)" % [fld, (obj.dot(fld).getCustomPragmaVal(fk)).table]
+        fkGroups.add """FOREIGN KEY ("$#") REFERENCES $#(id)""" % [fld, (obj.dot(fld).getCustomPragmaVal(fk)).table]
 
     colGroups.add colShmParts.join(" ")
 

--- a/tests/common/tmodel.nim
+++ b/tests/common/tmodel.nim
@@ -16,26 +16,26 @@ suite "Getting table and columns from Model":
       pet = newPet("cat", toy)
       person = newPerson("Alice", pet)
 
-    check person.col("name") == "name"
-    check pet.col("species") == "species"
+    check person.col("name") == "\"name\""
+    check pet.col("species") == "\"species\""
 
-    check person.cols == @["name", "pet"]
-    check person.cols(force = true) == @["name", "pet", "id"]
+    check person.cols == @["\"name\"", "\"pet\""]
+    check person.cols(force = true) == @["\"name\"", "\"pet\"", "\"id\""]
 
-    check person.fCol("name") == """"Person".name"""
-    check pet.fCol("species") == """"Pet".species"""
+    check person.fCol("name") == """"Person"."name""""
+    check pet.fCol("species") == """"Pet"."species""""
 
     check person.rfCols == @[
-      """"Person".name""",
-      """"Person".pet""",
-      """"pet".species""",
-      """"pet".favToy""",
-      """"pet_favToy".price""",
-      """"pet_favToy".id""",
-      """"pet".id""",
-      """"Person".id"""
+      """"Person"."name"""",
+      """"Person"."pet"""",
+      """"pet"."species"""",
+      """"pet"."favToy"""",
+      """"pet_favToy"."price"""",
+      """"pet_favToy"."id"""",
+      """"pet"."id"""",
+      """"Person"."id""""
     ]
-    check toy.rfCols == @[""""Toy".price""", """"Toy".id"""]
+    check toy.rfCols == @[""""Toy"."price"""", """"Toy"."id""""]
 
   test "Join groups":
     let
@@ -44,8 +44,8 @@ suite "Getting table and columns from Model":
       person = newPerson("Alice", pet)
 
     check person.joinGroups == @[
-      (""""Pet"""", """"pet"""", """"Person".pet""", """"pet".id"""),
-      (""""Toy"""", """"pet_favToy"""", """"pet".favToy""", """"pet_favToy".id""")
+      (""""Pet"""", """"pet"""", """"Person"."pet"""", """"pet"."id""""),
+      (""""Toy"""", """"pet_favToy"""", """"pet"."favToy"""", """"pet_favToy"."id"""")
     ]
 
   test "When related model has field with the type of the given model, expect name of that field as a string":

--- a/tests/postgres/tdbtypes.nim
+++ b/tests/postgres/tdbtypes.nim
@@ -4,7 +4,6 @@ import norm/[model, postgres, types]
 
 import ../models
 
-
 const
   dbHost = "postgres"
   dbUser = "postgres"
@@ -33,7 +32,7 @@ suite "Import dbTypes from norm/private/postgres/dbtypes":
 
   test "dbValue[DateTime] is imported":
     let users = @[newUser()].dup:
-      dbConn.select("""lastLogin <= $1""", ?now())
+      dbConn.select(""""lastLogin" <= $1""", ?now())
 
     check len(users) == 0
 

--- a/tests/postgres/tfkpragma.nim
+++ b/tests/postgres/tfkpragma.nim
@@ -70,6 +70,6 @@ suite "``fk`` pragma":
     for inpCustomer in inpCustomers.mitems:
       dbConn.insert inpCustomer
 
-    dbConn.select(outCustomers, """"userid" = $1""", userA.id)
+    dbConn.select(outCustomers, """"userId" = $1""", userA.id)
 
     check outCustomers === inpCustomers[0..^2]

--- a/tests/postgres/tfkpragma.nim
+++ b/tests/postgres/tfkpragma.nim
@@ -1,8 +1,10 @@
-import std/[unittest, times, strutils]
+import std/[unittest, times, strutils, logging]
 
 import norm/[model, postgres]
 
 import ../models
+
+addHandler(newConsoleLogger(levelThreshold = lvlDebug))
 
 
 const
@@ -41,8 +43,8 @@ suite "``fk`` pragma":
     check customer.id > 0
 
     let
-      userRows = dbConn.getAllRows(sql"""SELECT lastLogin, id FROM "User"""")
-      customerRows = dbConn.getAllRows(sql"""SELECT userId, email, id FROM "Customer"""")
+      userRows = dbConn.getAllRows(sql"""SELECT "lastLogin", "id" FROM "User" """)
+      customerRows = dbConn.getAllRows(sql"""SELECT "userId", "email", "id" FROM "Customer" """)
 
     check userRows.len == 1
     check userRows[0][1] == ?user.id

--- a/tests/postgres/trows.nim
+++ b/tests/postgres/trows.nim
@@ -1,5 +1,6 @@
 import std/[unittest, with, strutils, sugar, options]
 
+
 import norm/[model, postgres]
 
 import ../models
@@ -67,7 +68,7 @@ suite "Row CRUD":
 
     let
       personRows = dbConn.getAllRows(sql"""SELECT name, pet, id FROM "Person"""")
-      petRows = dbConn.getAllRows(sql"""SELECT species, favToy, id FROM "Pet"""")
+      petRows = dbConn.getAllRows(sql"""SELECT species, "favToy", id FROM "Pet"""")
       toyRows = dbConn.getAllRows(sql"""SELECT price, id FROM "Toy"""")
 
     check personRows.len == 1
@@ -219,7 +220,7 @@ suite "Row CRUD":
 
     let
       personRow = get dbConn.getRow(sql"""SELECT name, pet, id FROM "Person" WHERE id = $1""", person.id)
-      petRow = get dbConn.getRow(sql"""SELECT species, favToy, id FROM "Pet" WHERE id = $1""", pet.id)
+      petRow = get dbConn.getRow(sql"""SELECT species, "favToy", id FROM "Pet" WHERE id = $1""", pet.id)
       toyRow = get dbConn.getRow(sql"""SELECT price, id FROM "Toy" WHERE id = $1""", pet.favToy.id)
 
     check personRow == @[?"Bob", ?pet.id, ?person.id]

--- a/tests/postgres/ttables.nim
+++ b/tests/postgres/ttables.nim
@@ -56,7 +56,7 @@ suite "Table creation":
 
     check dbConn.getAllRows(qry, "FurnitureTable") == @[
       @[?"id", ?"bigint"],
-      @[?"legcount", ?dftDbInt]
+      @[?"legCount", ?dftDbInt]
     ]
 
   test "Create tables":
@@ -80,7 +80,7 @@ suite "Table creation":
     ]
 
     check dbConn.getAllRows(qry, "Pet") == @[
-      @[?"favtoy", ?"bigint"],
+      @[?"favToy", ?"bigint"],
       @[?"id", ?"bigint"],
       @[?"species", ?"text"]
     ]


### PR DESCRIPTION
This is a copy of #159  but with fixes applied by me to get the tests running.
@cmd410 @moigagoo 

The main reason I didn't commit them onto the branch of @cmd410 is because I actually don't know how ^^'

For the general description, refer to #159 and a related userstory #165 

GENERAL REMARK:
I noticed some worrying behaviour which I think might cause this PR to be one that break backwards compatibility.
A fair amount of the tests in postgres did not run because they either:

1) Displayed case-sensitive naming which they did not before (The tests where this was the case have that remarked in their commit message)
2) Displayed the **requirement** that specific columns (I think only FK columns?) be surrounded by quotation marks

That is new behaviour and a breaking change. It might of course also just be that I ran the tests under linux and this might be fine under windows, but it *is* something to take a look at either way.