### PR TITLE
Updated doc comments

### DIFF
--- a/src/norm/postgres.nim
+++ b/src/norm/postgres.nim
@@ -1,3 +1,4 @@
+
 import std/[os, logging, strutils, sequtils, options, sugar, strformat, tables]
 
 when (NimMajor, NimMinor) <= (1, 6):
@@ -243,6 +244,7 @@ proc rawSelect*[T: ref object](dbConn; qry: string, obj: var T, params: varargs[
   ``qry`` is the raw sql query whose contents are to be parsed into obj.
   The columns on ``qry`` must be in the same order as the fields on ``obj``.
   Table names must be written surrounded by quotation marks and are case sensititve.
+  Raises a `NotFoundError` if the query returns nothing.
   ]##
   let row = dbConn.getRow(sql qry, params)
   

--- a/src/norm/private/sqlite/rowutils.nim
+++ b/src/norm/private/sqlite/rowutils.nim
@@ -1,4 +1,4 @@
-## Procs to convert `Model <../../model.html#Model>`_ instances to ``ndb.sqlite.Row`` instances and back.
+## Procs to convert `Model <../../model.html#Model>`_ instances or ref object instances to ``ndb.sqlite.Row`` instances and back.
 
 import std/options
 
@@ -21,20 +21,20 @@ func isEmptyColumn*(row: Row, index: int): bool =
 
 ## This does the actual heavy lifting for parsing
 proc fromRowPos[T: ref object](obj: var T, row: Row, pos: var Natural, skip: static bool = false) =
-  ##[ Convert ``ndb.sqlite.Row`` instance into `Model`_ instance, from a given position.
+  ##[ Convert ``ndb.sqlite.Row`` instance into `ref object`_ instance, from a given position.
 
-  This is a helper proc to convert to `Model`_ instances that have fields of the same type.
+  This is a helper proc to convert to `ref object`_ instances that have fields of the same type.
   ]##
 
   for fld, dummyVal in T()[].fieldPairs:
-    when isRefObject(typeof(dummyVal)):                 ## If we're dealing with a ``Model`` field
-      if dot(obj, fld).toOptional().isSome:             ## and it's either a ``some Model`` or ``Model``
+    when isRefObject(typeof(dummyVal)):                 ## If we're dealing with a ``ref object`` field
+      if dot(obj, fld).toOptional().isSome:             ## and it's either a ``some ref object`` or ``ref object``
         var subMod = dot(obj, fld).toOptional().get()   ## then we try to populate it with the next ``row`` values.
 
-        if row.isEmptyColumn(pos):                      ## If we have a ``NULL`` at this point, we return an empty ``Model``:
-          when typeof(dummyVal) is Option:              ## ``val`` is guaranteed to be either ``Model`` or an ``Option[Model]`` at this point,
+        if row.isEmptyColumn(pos):                      ## If we have a ``NULL`` at this point, we return an empty ``ref object``:
+          when typeof(dummyVal) is Option:              ## ``val`` is guaranteed to be either ``ref object`` or an ``Option[ref object]`` at this point,
             when isRefObject(dummyVal):
-              dot(obj, fld) = none typeof(subMod)       ## and the fact that we got a ``NULL`` tells us it's an ``Option[Model]``,
+              dot(obj, fld) = none typeof(subMod)       ## and the fact that we got a ``NULL`` tells us it's an ``Option[ref object]``,
 
           inc pos
           subMod.fromRowPos(row, pos, skip = true)      ## Then we skip all the ``row`` values that should've gone into this submodel.
@@ -43,7 +43,7 @@ proc fromRowPos[T: ref object](obj: var T, row: Row, pos: var Natural, skip: sta
           inc pos                                       ##
           subMod.fromRowPos(row, pos)                   ## we actually populate the submodel.
 
-      else:                                             ## If the field is a ``none Model``,
+      else:                                             ## If the field is a ``none ref object``,
         inc pos                                         ## don't bother trying to populate it at all.
                                           
     else:
@@ -55,9 +55,9 @@ proc fromRowPos[T: ref object](obj: var T, row: Row, pos: var Natural, skip: sta
         inc pos
   
 proc fromRow*[T: ref object](obj: var T, row: Row) =
-  ##[ Populate `Model`_ instance from ``ndb.sqlite.Row`` instance.
+  ##[ Populate `ref object`_ instance from ``ndb.sqlite.Row`` instance.
 
-  Nested `Model`_ fields are populated from the same ``ndb.sqlite.Row`` instance.
+  Nested `ref object`_ fields are populated from the same ``ndb.sqlite.Row`` instance.
   ]##
 
   var pos: Natural = 0

--- a/src/norm/sqlite.nim
+++ b/src/norm/sqlite.nim
@@ -244,6 +244,7 @@ proc rawSelect*[T: ref object](dbConn; qry: string, obj: var T, params: varargs[
 
   ``qry`` is the raw sql query whose contents are to be parsed into obj.
   The columns on ``qry`` must be in the same order as the fields on ``obj``.
+  Raises a `NotFoundError` if the query returns nothing.
   ]##
   let row = dbConn.getRow(sql qry, params)
   


### PR DESCRIPTION
The doc comments for the `fromRowPos` proc were not quite correct anymore since they deal with all ref objects now, not just Model types.

Further added note that procs focussing on selecting a single row will raise a NotFoundError if no row is found.