### PR TITLE
#50 add connection pooling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,7 @@ tests/sqlite/ttransactions
 tests/sqlite/ttriangle
 tests/sqlite/tunique
 tests/sqlite/tuniquegroup
+tests/sqlite/trawselect
 
 tests/postgres/tcount
 tests/postgres/tdb
@@ -69,4 +70,6 @@ tests/postgres/ttransactions
 tests/postgres/ttriangle
 tests/postgres/tunique
 tests/postgres/tuniquegroup
+tests/postgres/trawselect
 
+nbook

--- a/src/norm/postgres.nim
+++ b/src/norm/postgres.nim
@@ -12,12 +12,13 @@ else:
 import ndb/postgres
 export postgres
 
-import private/postgres/[dbtypes, rowutils, llexec]
+import private/postgres/[dbtypes, rowutils, llexec, pool]
 import private/[dot, log]
 import model
 import pragmas
 
 export dbtypes
+export pool
 
 
 type
@@ -29,49 +30,7 @@ type
   NotFoundError* = object of KeyError
 
 
-const
-  dbHostEnv* = "DB_HOST"
-  dbUserEnv* = "DB_USER"
-  dbPassEnv* = "DB_PASS"
-  dbNameEnv* = "DB_NAME"
-
-
-# Sugar to get DB config from environment variables
-
-proc getDb*(): DbConn =
-  ## Create a ``DbConn`` from ``DB_HOST``, ``DB_USER``, ``DB_PASS``, and ``DB_NAME`` environment variables.
-
-  open(getEnv(dbHostEnv), getEnv(dbUserEnv), getEnv(dbPassEnv), getEnv(dbNameEnv))
-
-template withDb*(body: untyped): untyped =
-  ##[ Wrapper for DB operations.
-
-  Creates a ``DbConn`` with `getDb <#getDb>`_ as ``db`` variable,
-  runs your code in a ``try`` block, and closes ``db`` afterward.
-  ]##
-
-  block:
-    let db {.inject.} = getDb()
-
-    try:
-      body
-
-    finally:
-      close db
-
-
 using dbConn: DbConn
-
-
-# DB manipulation
-
-proc dropDb* =
-  ## Drop the database defined in environment variables.
-
-  let dbConn = open(getEnv(dbHostEnv), getEnv(dbUserEnv), getEnv(dbPassEnv), "template1")
-  dbConn.exec(sql "DROP DATABASE IF EXISTS $#" % getEnv(dbNameEnv))
-  close dbConn
-
 
 # Table manipulation
 

--- a/src/norm/postgres.nim
+++ b/src/norm/postgres.nim
@@ -29,6 +29,14 @@ type
     ]##
   NotFoundError* = object of KeyError
 
+# DB manipulation
+
+proc dropDb* =
+  ## Drop the database defined in environment variables.
+  #TODO: Figure out if this proc should exist, and if so, if the "template1" is actually needed. If this must look like this, it might be necessary to set env when starting things up just to make sure that you can grab things via env variables
+  let dbConn = open(getEnv(dbHostEnv), getEnv(dbUserEnv), getEnv(dbPassEnv), "template1")
+  dbConn.exec(sql "DROP DATABASE IF EXISTS $#" % getEnv(dbNameEnv))
+  close dbConn
 
 using dbConn: DbConn
 

--- a/src/norm/private/genericPool.nim
+++ b/src/norm/private/genericPool.nim
@@ -35,12 +35,12 @@ proc refillConnections(pool: var ConnectionPool) =
   ## Creates a number of database connections equal to the size of the connection pool
   ## and adds them to said pool. ONLY use this if you have acquired the lock on the pool!
   if not pool.isInitialized():
-    raise newException(PoolDefect, "TINYPOOL: Tried to use uninitialized database connection pool. Did you forget to call 'initConnectionPool' on startup? ")
+    raise newException(PoolDefect, "Tried to use uninitialized database connection pool. Did you forget to call 'initConnectionPool' on startup? ")
 
   for i in 1..pool.defaultPoolSize:
     pool.connections.add(pool.createConnectionProc())
 
-  log fmt "TINYPOOL: Refilled Pool to {pool.connections.len()} connections"
+  log fmt "Refilled database connection pool to {pool.connections.len()} connections"
 
 
 proc initConnectionPool*[Connection](pool: var ConnectionPool[Connection], createConnectionProc: CreateConnectionProc[Connection], poolSize: int, burstModeDuration: Duration = initDuration(minutes = 30)) =
@@ -51,7 +51,7 @@ proc initConnectionPool*[Connection](pool: var ConnectionPool[Connection], creat
   ## once it is triggered. burstModeDuration defaults to 30 minutes.
 
   if pool.isInitialized():
-    raise newException(PoolDefect, """TINYPOOL: Tried to initialize database connection pool a second time""")
+    raise newException(PoolDefect, """Tried to initialize database connection pool a second time""")
   
   pool = ConnectionPool[Connection](
     connections: @[],
@@ -66,7 +66,7 @@ proc initConnectionPool*[Connection](pool: var ConnectionPool[Connection], creat
 
   pool.refillConnections()
 
-  log fmt "TINYPOOL: Initialized pool with {pool.connections.len()} connections"
+  log fmt "Initialized database connection pool with {pool.connections.len()} connections"
 
 
 proc activateBurstMode(pool: var ConnectionPool) =
@@ -91,7 +91,7 @@ proc updateBurstModeState*[Connection](pool: var ConnectionPool[Connection]) =
   if getMonoTime() > pool.burstEndTime:
     pool.isInBurstMode = false
 
-    log "TINYPOOL: Deactivated Burst Mode"
+    log "Deactivated Burst Mode on database connection pool"
 
 
 proc extendBurstModeLifetime*[Connection](pool: var ConnectionPool[Connection]) =
@@ -100,7 +100,7 @@ proc extendBurstModeLifetime*[Connection](pool: var ConnectionPool[Connection]) 
   ## then the time is not extended. Throws a DbError if burst mode lifetime is
   ## attempted to be extended while pool is not in burst mode.
   if pool.isInBurstMode == false:
-    log "TINYPOOL: Tried to extend pool's burst mode while pool wasn't in burst mode. You have a logic issue!"
+    log "Tried to extend  database connection pool's burst mode while pool wasn't in burst mode. You have a logic issue!"
 
   let hasAlreadyMaxBurstModeDuration: bool = pool.burstEndTime - getMonoTime() > pool.burstModeDuration
   if hasAlreadyMaxBurstModeDuration:
@@ -117,7 +117,7 @@ proc borrowConnection*[Connection](pool: var ConnectionPool[Connection]): Connec
   ## Extends the pools burst mode if it is in burst mode and need for
   ## the same level of connections is still present.
   if not pool.isInitialized():
-    raise newException(PoolDefect, """TINYPOOL: Tried to borrow a connection from an uninitialized/destroyed database connection pool!""")
+    raise newException(PoolDefect, """Tried to borrow a connection from an uninitialized/destroyed database connection pool!""")
   
   withLock pool.lock:
     if pool.isEmpty():
@@ -128,7 +128,7 @@ proc borrowConnection*[Connection](pool: var ConnectionPool[Connection]): Connec
       
     result = pool.connections.pop()
 
-    log fmt "TINYPOOL: AFTER BORROW - Number of connections in pool: {pool.connections.len()}"
+    log fmt "Number of connections in database connection pool: {pool.connections.len()}"
 
 proc recycleConnection*[Connection](pool: var ConnectionPool[Connection], connection: Connection) {.gcsafe.} =
   ## Recycles a connection and tries to return it to the pool.
@@ -139,7 +139,7 @@ proc recycleConnection*[Connection](pool: var ConnectionPool[Connection], connec
   ## If the pool is in burst mode, it will allow an unlimited number of 
   ## connections into the pool.
   if not pool.isInitialized():
-    raise newException(PoolDefect, """TINYPOOL: Tried to recycle a connection back into an uninitialized/destroyed pool!""")
+    raise newException(PoolDefect, """Tried to recycle a connection back into an uninitialized/destroyed database connection pool!""")
   
   withLock pool.lock:
     pool.updateBurstModeState()
@@ -149,7 +149,7 @@ proc recycleConnection*[Connection](pool: var ConnectionPool[Connection], connec
     else:
       pool.connections.add(connection)
 
-    log fmt "TINYPOOL: AFTER RECYCLE - Number of connections in pool: {pool.connections.len()}"
+    log fmt "Number of connections in database connection pool: {pool.connections.len()}"
 
 
 proc destroyConnectionPool*[Connection](pool: var ConnectionPool[Connection]) =
@@ -163,7 +163,7 @@ proc destroyConnectionPool*[Connection](pool: var ConnectionPool[Connection]) =
   
   pool = nil
 
-  log fmt "TINYPOOL: Destroyed pool"
+  log fmt "Destroyed database connection pool"
 
 
 template withDb*(body: untyped): untyped =

--- a/src/norm/private/genericPool.nim
+++ b/src/norm/private/genericPool.nim
@@ -1,0 +1,182 @@
+import std/[times, monotimes, locks, strformat]
+import log
+import ndb/[sqlite, postgres]
+
+export monotimes
+export times
+export locks
+
+
+const
+  dbHostEnv* = "DB_HOST"
+  dbUserEnv* = "DB_USER"
+  dbPassEnv* = "DB_PASS"
+  dbNameEnv* = "DB_NAME"
+
+type PoolDefect* = object of Defect
+
+type Connection = sqlite.DbConn | postgres.DbConn
+type CreateConnectionProc*[Connection] = proc(): Connection
+
+type ConnectionPool*[Connection] = ref object
+  connections*: seq[Connection]
+  lock*: Lock
+  defaultPoolSize*: int
+  burstEndTime*: MonoTime # The point in time after which current burst mode ends if burst mode is active
+  isInBurstMode*: bool
+  createConnectionProc: CreateConnectionProc[Connection]
+  burstModeDuration: Duration 
+
+proc isEmpty*[Connection](pool: ConnectionPool[Connection]): bool = pool.connections.len() == 0
+proc isFull*[Connection](pool: ConnectionPool[Connection]): bool = pool.connections.len() >= pool.defaultPoolSize
+proc isInitialized*[Connection](pool: ConnectionPool[Connection]): bool = pool != nil
+
+proc refillConnections(pool: var ConnectionPool) =
+  ## Creates a number of database connections equal to the size of the connection pool
+  ## and adds them to said pool. ONLY use this if you have acquired the lock on the pool!
+  if not pool.isInitialized():
+    raise newException(PoolDefect, "TINYPOOL: Tried to use uninitialized database connection pool. Did you forget to call 'initConnectionPool' on startup? ")
+
+  for i in 1..pool.defaultPoolSize:
+    pool.connections.add(pool.createConnectionProc())
+
+  log fmt "TINYPOOL: Refilled Pool to {pool.connections.len()} connections"
+
+
+proc initConnectionPool*[Connection](pool: var ConnectionPool[Connection], createConnectionProc: CreateConnectionProc[Connection], poolSize: int, burstModeDuration: Duration = initDuration(minutes = 30)) =
+  ## Initializes the connection pool globally. To do so requires 
+  ## the path to the database (`databasePath`) which shall be connected to, 
+  ## and the number of connections within the pool under normal load (`poolSize`).
+  ## You can also set the initial duration of the burst mode (burstModeDuration)
+  ## once it is triggered. burstModeDuration defaults to 30 minutes.
+
+  if pool.isInitialized():
+    raise newException(PoolDefect, """TINYPOOL: Tried to initialize database connection pool a second time""")
+  
+  pool = ConnectionPool[Connection](
+    connections: @[],
+    isInBurstMode: false,
+    burstEndTime: getMonoTime(),
+    defaultPoolSize: poolSize,
+    createConnectionProc: createConnectionProc,
+    burstModeDuration: burstModeDuration
+  )
+
+  initLock(pool.lock)
+
+  pool.refillConnections()
+
+  log fmt "TINYPOOL: Initialized pool with {pool.connections.len()} connections"
+
+
+proc activateBurstMode(pool: var ConnectionPool) =
+  ## Activates burst mode on the connection pool. Burst mode is active
+  ## for a limited time after activation, determined by the burstModeDuration
+  ## set during initialization. While active, it allows the pool to contain more
+  ## connections than it can contain by default and replenishes the connections 
+  ## within the pool. If triggered while burst mode is already active, this 
+  ## will refill the pool and reset the timer.
+  pool.isInBurstMode = true
+  pool.burstEndTime = getMonoTime() + pool.burstModeDuration
+  
+  pool.refillConnections()
+
+
+proc updateBurstModeState*[Connection](pool: var ConnectionPool[Connection]) =
+  ## Checks whether the burst mode on the connection pool has run out and turns
+  ## it off if so. Does nothing if burst mode is already off.
+  if not pool.isInBurstMode:
+    return
+
+  if getMonoTime() > pool.burstEndTime:
+    pool.isInBurstMode = false
+
+    log "TINYPOOL: Deactivated Burst Mode"
+
+
+proc extendBurstModeLifetime*[Connection](pool: var ConnectionPool[Connection]) =
+  ## Delays the time after which burst mode is turned off for the given pool.
+  ## If the point in time is further away from now than the pools boostModeDuration
+  ## then the time is not extended. Throws a DbError if burst mode lifetime is
+  ## attempted to be extended while pool is not in burst mode.
+  if pool.isInBurstMode == false:
+    log "TINYPOOL: Tried to extend pool's burst mode while pool wasn't in burst mode. You have a logic issue!"
+
+  let hasAlreadyMaxBurstModeDuration: bool = pool.burstEndTime - getMonoTime() > pool.burstModeDuration
+  if hasAlreadyMaxBurstModeDuration:
+    return
+
+  pool.burstEndTime = pool.burstEndTime + initDuration(seconds = 5)
+
+
+proc borrowConnection*[Connection](pool: var ConnectionPool[Connection]): Connection {.gcsafe.} =
+  ## Tries to borrow a database connection from the connection pool.
+  ## This operation is thread-safe, as it locks the pool while trying to
+  ## borrow a connection from it.
+  ## Can activate burst mode if larger amounts of connections are necessary.
+  ## Extends the pools burst mode if it is in burst mode and need for
+  ## the same level of connections is still present.
+  if not pool.isInitialized():
+    raise newException(PoolDefect, """TINYPOOL: Tried to borrow a connection from an uninitialized/destroyed database connection pool!""")
+  
+  withLock pool.lock:
+    if pool.isEmpty():
+      pool.activateBurstMode()
+
+    elif not pool.isFull() and pool.isInBurstMode: 
+      pool.extendBurstModeLifetime()
+      
+    result = pool.connections.pop()
+
+    log fmt "TINYPOOL: AFTER BORROW - Number of connections in pool: {pool.connections.len()}"
+
+proc recycleConnection*[Connection](pool: var ConnectionPool[Connection], connection: Connection) {.gcsafe.} =
+  ## Recycles a connection and tries to return it to the pool.
+  ## This operation is thread-safe, as it locks the pool while trying to return
+  ## the connection.
+  ## If the pool is full and not in burst mode, the connection is superfluous 
+  ## and thusclosed and garbage collected.
+  ## If the pool is in burst mode, it will allow an unlimited number of 
+  ## connections into the pool.
+  if not pool.isInitialized():
+    raise newException(PoolDefect, """TINYPOOL: Tried to recycle a connection back into an uninitialized/destroyed pool!""")
+  
+  withLock pool.lock:
+    pool.updateBurstModeState()
+
+    if pool.isFull() and not pool.isInBurstMode:
+      connection.close()
+    else:
+      pool.connections.add(connection)
+
+    log fmt "TINYPOOL: AFTER RECYCLE - Number of connections in pool: {pool.connections.len()}"
+
+
+proc destroyConnectionPool*[Connection](pool: var ConnectionPool[Connection]) =
+  ## Destroys the currently initialized pool. This also ensures that all
+  ## connections currently within the pool are closed.
+  if not pool.isInitialized():
+    return
+
+  for connection in pool.connections:
+    connection.close()
+  
+  pool = nil
+
+  log fmt "TINYPOOL: Destroyed pool"
+
+
+template withDb*(body: untyped): untyped =
+  ## Wrapper for DB operations.
+
+  ## Borrows a database connection ``DbConn`` from the connection pool,
+  ## runs your code in a ``try`` block and returns the connection to the pool.
+
+  block: #ensures db connection exists only within the scope of this block
+    let db {.inject.} = borrowConnection()
+
+    try:
+      body
+
+    finally:
+      recycleConnection(connection)

--- a/src/norm/private/postgres/pool.nim
+++ b/src/norm/private/postgres/pool.nim
@@ -22,14 +22,7 @@ proc getDb*(): DbConn =
   open(getEnv(dbHostEnv), getEnv(dbUserEnv), getEnv(dbPassEnv), getEnv(dbNameEnv))
 
 
-# DB manipulation
 
-proc dropDb* =
-  ## Drop the database defined in environment variables.
-  #TODO: Figure out if this proc should exist, and if so, if the "template1" is actually needed. If this must look like this, it might be necessary to set env when starting things up just to make sure that you can grab things via env variables
-  let dbConn = open(getEnv(dbHostEnv), getEnv(dbUserEnv), getEnv(dbPassEnv), "template1")
-  dbConn.exec(sql "DROP DATABASE IF EXISTS $#" % getEnv(dbNameEnv))
-  close dbConn
 
 
 

--- a/src/norm/private/postgres/pool.nim
+++ b/src/norm/private/postgres/pool.nim
@@ -1,0 +1,52 @@
+import ../genericPool
+import ../log
+import ndb/postgres
+import std/[strutils, os]
+
+export PoolDefect
+export dbHostEnv
+export dbUserEnv
+export dbPassEnv
+export dbNameEnv
+export withDb
+
+var POSTGRES_POOL {.global.}: ConnectionPool[DbConn] = nil
+
+
+
+
+# Sugar to get DB config from environment variables
+
+proc getDb*(): DbConn =
+  ## Create a ``DbConn`` from ``DB_HOST``, ``DB_USER``, ``DB_PASS``, and ``DB_NAME`` environment variables.
+  open(getEnv(dbHostEnv), getEnv(dbUserEnv), getEnv(dbPassEnv), getEnv(dbNameEnv))
+
+
+# DB manipulation
+
+proc dropDb* =
+  ## Drop the database defined in environment variables.
+  #TODO: Figure out if this proc should exist, and if so, if the "template1" is actually needed. If this must look like this, it might be necessary to set env when starting things up just to make sure that you can grab things via env variables
+  let dbConn = open(getEnv(dbHostEnv), getEnv(dbUserEnv), getEnv(dbPassEnv), "template1")
+  dbConn.exec(sql "DROP DATABASE IF EXISTS $#" % getEnv(dbNameEnv))
+  close dbConn
+
+
+
+proc borrowConnection*(): DbConn {.gcsafe.} =
+  {.cast(gcsafe).}:
+    POSTGRES_POOL.borrowConnection()
+
+proc recycleConnection*(connection: var DbConn) {.gcsafe.} =
+  {.cast(gcsafe).}:
+    POSTGRES_POOL.recycleConnection(move connection)
+
+proc initConnectionPool*(
+  createConnectionProc: CreateConnectionProc[DbConn] = getDb,
+  poolSize: int = 4,
+  burstModeDuration: Duration = initDuration(minutes = 30)
+) =
+  POSTGRES_POOL.initConnectionPool(createConnectionProc, poolSize, burstModeDuration)
+
+proc destroyConnectionPool*() =
+  POSTGRES_POOL.destroyConnectionPool()

--- a/src/norm/private/sqlite/pool.nim
+++ b/src/norm/private/sqlite/pool.nim
@@ -16,12 +16,6 @@ proc getDb*(): DbConn =
   ## Create a ``DbConn`` from ``DB_HOST`` environment variable.
   open(getEnv(dbHostEnv), "", "", "")
 
-proc dropDb* =
-  ## Remove the DB file defined in environment variable.
-  #TODO: Figure out if this proc should exist, and if so, if the "template1" is actually needed. If this must look like this, it might be necessary to set env when starting things up just to make sure that you can grab things via env variables
-  removeFile(getEnv(dbHostEnv))
-
-
 # Handling DB connections
 
 proc borrowConnection*(): DbConn {.gcsafe.} =

--- a/src/norm/private/sqlite/pool.nim
+++ b/src/norm/private/sqlite/pool.nim
@@ -1,0 +1,51 @@
+import ../log
+import ../genericPool
+import ndb/sqlite
+import std/os
+
+export PoolDefect
+export dbHostEnv
+export withDb
+
+var SQLITE_POOL {.global.}: ConnectionPool[DbConn] = nil
+
+
+# Sugar to get DB config from environment variables
+
+proc getDb*(): DbConn =
+  ## Create a ``DbConn`` from ``DB_HOST`` environment variable.
+  open(getEnv(dbHostEnv), "", "", "")
+
+proc dropDb* =
+  ## Remove the DB file defined in environment variable.
+  #TODO: Figure out if this proc should exist, and if so, if the "template1" is actually needed. If this must look like this, it might be necessary to set env when starting things up just to make sure that you can grab things via env variables
+  removeFile(getEnv(dbHostEnv))
+
+
+# Handling DB connections
+
+proc borrowConnection*(): DbConn {.gcsafe.} =
+  {.cast(gcsafe).}:
+    SQLITE_POOL.borrowConnection()
+
+proc recycleConnection*(connection: var DbConn) {.gcsafe.} =
+  {.cast(gcsafe).}:
+    SQLITE_POOL.recycleConnection(move connection)
+
+proc initConnectionPool*(
+  createConnectionProc: CreateConnectionProc[DbConn] = getDb,
+  poolSize: int = 4,
+  burstModeDuration: Duration = initDuration(minutes = 30)
+) =
+  SQLITE_POOL.initConnectionPool(createConnectionProc, poolSize, burstModeDuration)
+
+proc initConnectionPool*(
+  databasePath: string = ":memory:",
+  poolSize: int = 4,
+  burstModeDuration: Duration = initDuration(minutes = 30)
+) =
+  let createConnectionProc: CreateConnectionProc[DbConn] = proc(): DbConn = open(databasePath, "", "", "")
+  initConnectionPool(createConnectionProc, poolSize, burstModeDuration)
+
+proc destroyConnectionPool*() =
+  SQLITE_POOL.destroyConnectionPool()

--- a/src/norm/sqlite.nim
+++ b/src/norm/sqlite.nim
@@ -28,8 +28,13 @@ type
     ]##
   NotFoundError* = object of KeyError
 
-# Sugar to get DB config from environment variables
 
+# DB manipulation
+
+proc dropDb* =
+  ## Remove the DB file defined in environment variable.
+  #TODO: Figure out if this proc should exist, and if so, if the "template1" is actually needed. If this must look like this, it might be necessary to set env when starting things up just to make sure that you can grab things via env variables
+  removeFile(getEnv(dbHostEnv))
 
 using dbConn: DbConn
 

--- a/src/norm/sqlite.nim
+++ b/src/norm/sqlite.nim
@@ -11,12 +11,13 @@ else:
 import ndb/sqlite
 export sqlite
 
-import private/sqlite/[dbtypes, rowutils]
+import private/sqlite/[dbtypes, rowutils, pool]
 import private/[dot, log]
 import model
 import pragmas
 
 export dbtypes
+export pool
 
 
 type
@@ -27,43 +28,10 @@ type
     ]##
   NotFoundError* = object of KeyError
 
-const dbHostEnv* = "DB_HOST"
-
-
 # Sugar to get DB config from environment variables
-
-proc getDb*(): DbConn =
-  ## Create a ``DbConn`` from ``DB_HOST`` environment variable.
-
-  open(getEnv(dbHostEnv), "", "", "")
-
-template withDb*(body: untyped): untyped =
-  ##[ Wrapper for DB operations.
-
-  Creates a ``DbConn`` with `getDb <#getDb>`_ as ``db`` variable,
-  runs your code in a ``try`` block, and closes ``db`` afterward.
-  ]##
-
-  block:
-    let db {.inject.} = getDb()
-
-    try:
-      body
-
-    finally:
-      close db
 
 
 using dbConn: DbConn
-
-
-# DB manipulation
-
-proc dropDb* =
-  ## Remove the DB file defined in environment variable.
-
-  removeFile(getEnv(dbHostEnv))
-
 
 # Table manipulation
 


### PR DESCRIPTION
**THIS IS NOT A FINISHED PR**

PR for Issue #50

<h3> Note </h3>
I would like to cooperate on this with you @moigagoo though, to throw ideas back and forth for how exactly we implement this in norm.
I've provided a first stab on how this could look like. Please give your general thoughts as well as your specific thoughts about the suggestions I'm making in the "How the pool works" section (marked with "Idea N", N being a number).

<h3> How the pool works </h3>

The pool is basically just a glorified private global variable of type `seq[DbConn]` with a lock for thread-safe access.
This seq can not be interacted with outside of the specifically provided procs that make up the public API of this module.

Initially you basically just need to initialize the pool.
Upon initialization it will create said seq and populate it with `DbConn` instances created via a proc that creates connections.
That proc **can** be supplied by the user, or they supply nothing, in that case the current `getDb` proc is used to create connections. (**Idea 1**: We may want to add checks that if getDb is used, that the env variables must've been set and that we just crash the program if they haven't been). 

The user then can interact with the pool in an identical manner to tinyPool and more:
1) borrow/recycle connections
2) use `withDb`  (which now borrows/recycles connections instead of creating/closing them)
3) use `getDb` to actually create a connection (**Idea 2**: I do not think it is a good idea to allow the user to circumvent the pool as there is no benefit to them and instead this puts them at risk if they forget to close a connection. I would like to make this proc private, even if that is a breaking API change)
4) use dropDb to drop the database (**Idea 3**: I am currently uncertain about whether having this makes sense, I feel tempted to suggest that we just remove this proc as well to keep the API simpler)

Should the user call `borrowConnection` while the pool is empty it goes into burst mode (functionality is the same as in tinypool, so here the explanation from my readme there):
> If more connections are needed than it has, the pool will temporarily go into "burst mode" and automatically refill with a new batch of connections, the amount of which is determined by the poolSize.
While the pool is in burst mode it can hold an unlimited amount of connections.
While the pool is not in burst mode, any superfluous connection that is returned to it gets closed.
Burst mode ends after a specified duration (30 minutes), though that gets extended if the connections from the added batch are still needed.

<h3> Code organization </h3>

`genericPool.nim` is the center-piece for logic regarding handling connection pools. It also contains and exports all possible gobal variables needed for interacting with any kind of connection pool.
It gets imported by individual `pool.nim` files that basically just contain the instance of the pool as well as the public API procs made specific for this particular pool type (aka whether it's for `ndb/sqlite` or `ndb/postgres`. It further exports the global variables needed to interact with this specific kind of connection pool.
`pool.nim` modules then get imported and exported by the respective `sqlite.nim`/`postgres.nim` modules, making the API for interacting with the connection pool immediately accessible as part of importing `sqlite.nim`/`postgres.nim`.

I've further refactored out various things from the individual `sqlite.nim` and `postgres.nim` modules into `genericPool.nim`, since these are about handling the connection to the database and it made sense to me to centralize that into `genericPool.nim`.

If you have a different idea on how this should be structured please give feedback! As stated, this is just a first stab at it.

<h3> Questions </h3>

I have a question here though:
I have some trouble understanding how the proc `dropDb` for postgres works:
```nim
proc dropDb* =
  ## Drop the database defined in environment variables.
  let dbConn = open(getEnv(dbHostEnv), getEnv(dbUserEnv), getEnv(dbPassEnv), "template1")
  dbConn.exec(sql "DROP DATABASE IF EXISTS $#" % getEnv(dbNameEnv))
  close dbConn
```
What exactly is "template1" and why is it inserted there instead of using the `dbNameEnv` variable?

