### PR TITLE
Nim2 compatibility

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,11 +10,42 @@ on:
 
 jobs:
   Tests:
+    timeout-minutes: 30
+
+    name: Nim ${{ matrix.nim-version }}
     runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        nim-version: ['1.4.0', '1.6.10', 'devel']
+
+
+    services:
+      postgres:
+        image: postgres
+        env:
+          POSTGRES_PASSWORD: postgres
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports: # Needed so we don't need to run in a container
+          - 5432:5432
+
     steps:
-      - uses: actions/checkout@v2
-      - name: Tests
-        run: docker-compose run tests
+      - uses: actions/checkout@v1
+      - uses: jiro4989/setup-nim-action@v1
+        with:
+          nim-version: ${{ matrix.nim-version }}
+
+      - run: nimble install -Y
+
+      - name: Run tests
+        run: testament run
+        env:
+          PGHOST: localhost
+
 
   Book:
     runs-on: ubuntu-latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,7 @@ jobs:
 
     strategy:
       matrix:
-        nim-version: ['1.4.0', '1.6.10', 'devel']
+        nim-version: ['1.6.10', 'devel']
 
 
     services:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -42,7 +42,7 @@ jobs:
       - run: nimble install -Y
 
       - name: Run tests
-        run: testament run
+        run: testament all
         env:
           PGHOST: localhost
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 - [Documentation](https://norm.nim.town/) (built with [nimibook](https://github.com/pietroppeter/nimibook))
 - [API index](https://norm.nim.town/apidocs/theindex.html)
 - [norman](https://github.com/moigagoo/norman): scaffolder and migration manager for Norm
-- [shopapp](https://github.com/moigagoo/shopapp): a proof-of-concept for a webapp created with Karax for frontend, Jester for API server, Norm for ORM, and Norman for migration management 
+- [shopapp](https://github.com/moigagoo/shopapp): a proof-of-concept for a webapp created with Karax for frontend, Jester for API server, Norm for ORM, and Norman for migration management
 
 ## Installation
 
@@ -26,10 +26,15 @@ Any contributions are welcome: pull requests, code reviews, documentation improv
 
 -   Run the tests before and after you change the code.
 
-    The recommended way to run the tests is with Docker Compose:
+    The recommended way to run the tests is via nimble commands:
+        $ nimble startContainers                                # Starts docker containers needed for testing
+        $ nimble startContainers sudo                           # Starts docker containers using sudo
 
-        $ docker-compose run --rm tests                         # run all test suites
-        $ docker-compose run --rm test tests/common/tmodel.nim  # run a single test suite
+        $ nimble allTests                                       # run all test suites
+        $ nimble singleTest tests/common/tmodel.nim             # run a single/list of test suite/s
+
+        $ nimble stopContainers                                 # Stops and shuts down docker-containers
+        $ nimble startContainers sudo                           # Stops docker container using sudo
 
 -   Use camelCase instead of snake_case.
 

--- a/book/customDatatypes.nim
+++ b/book/customDatatypes.nim
@@ -19,7 +19,7 @@ By default, Norm can deal with the following Nim types:
   - ``DateTime``
   - ``Model``
 
-It does so by interacting with the database through a package called ``ndb``. With ``ndb``, Norm converts these Nim types into the ``DbValue`` type which it then can convert to and from the various database-types.
+It does so by interacting with the database through a package called ``lowdb``. With ``lowdb``, Norm converts these Nim types into the ``DbValue`` type which it then can convert to and from the various database-types.
 
 More specifically, Norm does this by specifying 3 procs. These procs specify which database-type to convert ``DbValue`` to, how to convert the Nim type to ``DbValue`` and how to convert ``DbValue`` to the Nim type.
 

--- a/norm.nimble
+++ b/norm.nimble
@@ -10,7 +10,7 @@ skipDirs      = @["tests", "htmldocs"]
 
 # Dependencies
 
-requires "nim >= 1.4.0", "ndb >= 0.19.9"
+requires "nim >= 1.4.0", "lowdb >= 0.1.0"
 
 
 task test, "Run tests":
@@ -19,8 +19,8 @@ task test, "Run tests":
 task book, "Generate book":
   rmDir "docs"
   exec "nimble install -y nimib nimibook@#280a626a902745b378cc2186374f14c904c9a606"
-  exec "nim r -d:release nbook.nim update"
-  exec "nim r -d:release nbook.nim build"
+  exec "nim r -d:release --mm:refc nbook.nim update"
+  exec "nim r -d:release --mm:refc nbook.nim build"
   cpFile("CNAME", "docs/CNAME")
 
 task docs, "Generate docs":

--- a/norm.nimble
+++ b/norm.nimble
@@ -10,7 +10,7 @@ skipDirs      = @["tests", "htmldocs"]
 
 # Dependencies
 
-requires "nim >= 1.4.0", "lowdb >= 0.1.0"
+requires "nim >= 1.4.0", "lowdb >= 0.1.1"
 
 
 task test, "Run tests":

--- a/norm.nimble
+++ b/norm.nimble
@@ -18,7 +18,7 @@ task test, "Run tests":
 
 task setupBook, "Compiles the nimibook CLI-binary used for generating the docs":
   exec "nimble install -y nimib nimibook@#280a626a902745b378cc2186374f14c904c9a606"
-  exec "nim c -d:release --mm:orc --deepcopy:on nbook.nim"
+  exec "nim c -d:release --mm:refc nbook.nim"
 
 task book, "Generate book":
   rmDir "docs"

--- a/norm.nimble
+++ b/norm.nimble
@@ -16,11 +16,15 @@ requires "nim >= 1.4.0", "lowdb >= 0.1.1"
 task test, "Run tests":
   exec "testament all"
 
+task setupBook, "Compiles the nimibook CLI-binary used for generating the docs":
+  exec "nimble install -y nimib nimibook@#280a626a902745b378cc2186374f14c904c9a606"
+  exec "nim c -d:release --mm:orc --deepcopy:on nbook.nim"
+
 task book, "Generate book":
   rmDir "docs"
-  exec "nimble install -y nimib nimibook@#280a626a902745b378cc2186374f14c904c9a606"
-  exec "nim r -d:release --mm:refc nbook.nim update"
-  exec "nim r -d:release --mm:refc nbook.nim build"
+  exec "nimble setupBook"
+  exec "./nbook --mm:orc --deepcopy:on update"
+  exec "./nbook --mm:orc --deepcopy:on build"
   cpFile("CNAME", "docs/CNAME")
 
 task docs, "Generate docs":

--- a/norm.nimble
+++ b/norm.nimble
@@ -27,3 +27,24 @@ task docs, "Generate docs":
   rmDir "docs/apidocs"
   exec "nimble doc --outdir:docs/apidocs --project --index:on src/norm"
 
+import std/[strutils, sequtils, strformat]
+
+task dockerTests, "Run all containerized tests":
+  let wantsSudoExecution = commandLineParams.anyIt(it == "sudo")
+  var command = "docker-compose run --rm tests"
+  if wantsSudoExecution:
+    command = fmt"sudo {command}"
+
+  exec command
+
+task singleDockerTest, "Run containerized tests for a specific test file":
+  let testArguments = commandLineParams.filterIt(it.startsWith("test"))
+
+  let wantsSudoExecution = commandLineParams.anyIt(it == "sudo")
+  var command = "docker-compose run --rm tests"
+
+  for argument in testArguments:
+    var command = fmt"docker-compose run --rm test {argument}"
+    if wantsSudoExecution:
+      command = fmt"sudo {command}"
+    exec command

--- a/src/norm/postgres.nim
+++ b/src/norm/postgres.nim
@@ -433,7 +433,7 @@ template transaction*(dbConn; body: untyped): untyped =
     log(commitQry)
     dbConn.exec(sql commitQry)
 
-  except:
+  except CatchableError:
     log(rollbackQry)
     dbConn.exec(sql rollbackQry)
 

--- a/src/norm/postgres.nim
+++ b/src/norm/postgres.nim
@@ -8,7 +8,7 @@ else:
   import std/macros
   export macros
 
-import ndb/postgres
+import lowdb/postgres
 export postgres
 
 import private/postgres/[dbtypes, rowutils, llexec]
@@ -159,7 +159,7 @@ proc createTables*[T: Model](dbConn; obj: T) =
     log(qry)
 
     dbConn.exec(sql qry)
- 
+
 
 # Row manupulation
 

--- a/src/norm/postgres.nim
+++ b/src/norm/postgres.nim
@@ -217,7 +217,7 @@ proc insert*[T: Model](dbConn; objs: var openArray[T], force = false) =
   for obj in objs.mitems:
     dbConn.insert(obj, force)
 
-proc select*[T: Model](dbConn; obj: var T, cond: string, params: varargs[DbValue, dbValue]) {.raises: {NotFoundError, ValueError, DbError, LoggingError}.} =
+proc select*[T: Model](dbConn; obj: var T, cond: string, params: varargs[DbValue, dbValue]) {.raises: {NotFoundError, ValueError, DbError, LoggingError, Exception}.} =
   ##[ Populate a `Model`_ instance and its `Model`_ fields from DB.
 
   ``cond`` is condition for ``WHERE`` clause but with extra features:
@@ -243,7 +243,7 @@ proc select*[T: Model](dbConn; obj: var T, cond: string, params: varargs[DbValue
 
   obj.fromRow(get row)
 
-proc select*[T: Model](dbConn; objs: var seq[T], cond: string, params: varargs[DbValue, dbValue]) {.raises: {ValueError, DbError, LoggingError}.} =
+proc select*[T: Model](dbConn; objs: var seq[T], cond: string, params: varargs[DbValue, dbValue]) {.raises: {ValueError, DbError, LoggingError, Exception}.} =
   ##[ Populate a sequence of `Model`_ instances from DB.
 
   ``objs`` must have at least one item.
@@ -281,7 +281,7 @@ proc selectAll*[T: Model](dbConn; objs: var seq[T]) =
 
   dbConn.select(objs, "TRUE")
 
-proc rawSelect*[T: ref object](dbConn; qry: string, obj: var T, params: varargs[DbValue, dbValue]) {.raises: {ValueError, DbError, LoggingError}.} =
+proc rawSelect*[T: ref object](dbConn; qry: string, obj: var T, params: varargs[DbValue, dbValue]) {.raises: {ValueError, DbError, LoggingError, Exception}.} =
   ##[ Populate a ref object instance ``obj`` and its ref object fields from DB.
 
   ``qry`` is the raw sql query whose contents are to be parsed into obj.
@@ -296,7 +296,7 @@ proc rawSelect*[T: ref object](dbConn; qry: string, obj: var T, params: varargs[
 
   obj.fromRow(get row)
 
-proc rawSelect*[T: ref object](dbConn; qry: string, objs: var seq[T], params: varargs[DbValue, dbValue]) {.raises: {ValueError, DbError, LoggingError}.} =
+proc rawSelect*[T: ref object](dbConn; qry: string, objs: var seq[T], params: varargs[DbValue, dbValue]) {.raises: {ValueError, DbError, LoggingError, Exception}.} =
   ##[ Populate a sequence of ref object instances from DB.
 
   ``qry`` is the raw sql query whose contents are to be parsed into ``objs``.

--- a/src/norm/private/log.nim
+++ b/src/norm/private/log.nim
@@ -5,15 +5,15 @@ type
 when defined(normDebug):
   import std/[logging, strutils]
 
-  proc log*(msg: string) {.raises: LoggingError.} =
+  proc log*(msg: string) {.raises: {LoggingError, Exception}.} =
     ## Log arbitrary message with debug level if the app is compiled with ``-d:normDebug``.
 
     try:
       debug msg
-    except:
+    except CatchableError:
       raise newException(LoggingError, getCurrentExceptionMsg())
 
-  proc log*(qry, paramstr: string) {.raises: {ValueError, LoggingError}.} =
+  proc log*(qry, paramstr: string) {.raises: {ValueError, LoggingError, Exception}.} =
     ## Log query with params with debug level if the app is compiled with ``-d:normDebug``.
 
     log "$# <- $#" % [qry, paramstr]

--- a/src/norm/private/log.nim
+++ b/src/norm/private/log.nim
@@ -5,15 +5,15 @@ type
 when defined(normDebug):
   import std/[logging, strutils]
 
-  proc log*(msg: string) {.raises: {LoggingError, Exception}.} =
+  proc log*(msg: string) {.raises: {LoggingError}.} =
     ## Log arbitrary message with debug level if the app is compiled with ``-d:normDebug``.
 
     try:
       debug msg
-    except CatchableError:
+    except Exception:
       raise newException(LoggingError, getCurrentExceptionMsg())
 
-  proc log*(qry, paramstr: string) {.raises: {ValueError, LoggingError, Exception}.} =
+  proc log*(qry, paramstr: string) {.raises: {ValueError, LoggingError}.} =
     ## Log query with params with debug level if the app is compiled with ``-d:normDebug``.
 
     log "$# <- $#" % [qry, paramstr]

--- a/src/norm/private/postgres/dbtypes.nim
+++ b/src/norm/private/postgres/dbtypes.nim
@@ -52,9 +52,9 @@ func dbValue*[T: Model](val: Option[T]): DbValue =
   else:
     dbValue(nil)
 
-func dbValue*[_](val: StringOfCap[_]): DbValue = dbValue(string(val))
+func dbValue*[T](val: StringOfCap[T]): DbValue = dbValue(string(val))
 
-func dbValue*[_](val: PaddedStringOfCap[_]): DbValue = dbValue(string(val))
+func dbValue*[T](val: PaddedStringOfCap[T]): DbValue = dbValue(string(val))
 
 
 # Converter funcs from ``DbValue`` instances to Nim types:
@@ -67,9 +67,9 @@ func to*(dbVal; T: typedesc[SomeFloat]): T = dbVal.f.T
 
 func to*(dbVal; T: typedesc[string]): T = dbVal.s
 
-func to*[_](dbVal; T: typedesc[StringOfCap[_]]): T = dbVal.o.value.T
+func to*[U](dbVal; T: typedesc[StringOfCap[U]]): T = dbVal.o.value.T
 
-func to*[_](dbVal; T: typedesc[PaddedStringOfCap[_]]): T = dbVal.o.value.T
+func to*[U](dbVal; T: typedesc[PaddedStringOfCap[U]]): T = dbVal.o.value.T
 
 func to*(dbVal; T: typedesc[bool]): T = dbVal.b
 

--- a/src/norm/private/postgres/dbtypes.nim
+++ b/src/norm/private/postgres/dbtypes.nim
@@ -21,7 +21,7 @@ func dbType*(T: typedesc[int16]): string = "SMALLINT"
 
 func dbType*(T: typedesc[int32]): string = "INTEGER"
 
-func dbType*(T: typedesc[int64]): string = "BIGINT"
+func dbType*(T: typedesc[int64 | Positive]): string = "BIGINT"
 
 func dbType*(T: typedesc[float32]): string = "REAL"
 

--- a/src/norm/private/postgres/dbtypes.nim
+++ b/src/norm/private/postgres/dbtypes.nim
@@ -67,9 +67,9 @@ func to*(dbVal; T: typedesc[SomeFloat]): T = dbVal.f.T
 
 func to*(dbVal; T: typedesc[string]): T = dbVal.s
 
-func to*[U](dbVal; T: typedesc[StringOfCap[U]]): T = dbVal.o.value.T
+func to*[T1](dbVal; T2: typedesc[StringOfCap[T1]]): T2 = dbVal.o.value.T2
 
-func to*[U](dbVal; T: typedesc[PaddedStringOfCap[U]]): T = dbVal.o.value.T
+func to*[T1](dbVal; T2: typedesc[PaddedStringOfCap[T1]]): T2 = dbVal.o.value.T2
 
 func to*(dbVal; T: typedesc[bool]): T = dbVal.b
 

--- a/src/norm/private/postgres/dbtypes.nim
+++ b/src/norm/private/postgres/dbtypes.nim
@@ -21,7 +21,7 @@ func dbType*(T: typedesc[int16]): string = "SMALLINT"
 
 func dbType*(T: typedesc[int32]): string = "INTEGER"
 
-func dbType*(T: typedesc[int64 | Positive]): string = "BIGINT"
+func dbType*(T: typedesc[int64 | Positive | int]): string = "BIGINT"
 
 func dbType*(T: typedesc[float32]): string = "REAL"
 

--- a/src/norm/private/postgres/dbtypes.nim
+++ b/src/norm/private/postgres/dbtypes.nim
@@ -1,15 +1,15 @@
-##[ Funcs to convert between Nim types and SQLite types and between Nim values and ``ndb.postgres.DbValue``.
+##[ Funcs to convert between Nim types and SQLite types and between Nim values and ``lowdb.postgres.DbValue``.
 
 To add support for ``YourType``, define three funcs:
 - ``dbType(T: typedesc[YourType]) -> string`` that returns SQL type for given ``YourType``
-- ``dbValue(YourType) -> DbValue`` that converts instances of ``YourType`` to ``ndb.sqlite.DbValue``
-- ``to(DbValue, T: typedesc[YourType]) -> T`` that converts ``ndb.sqlite.DbValue`` instances to ``YourType``.
+- ``dbValue(YourType) -> DbValue`` that converts instances of ``YourType`` to ``lowdb.sqlite.DbValue``
+- ``to(DbValue, T: typedesc[YourType]) -> T`` that converts ``lowdb.sqlite.DbValue`` instances to ``YourType``.
 ]##
 
 
 import std/[options, times, strutils]
 
-import ndb/postgres
+import lowdb/postgres
 
 import ../../model
 import ../../types

--- a/src/norm/private/postgres/dbtypes.nim
+++ b/src/norm/private/postgres/dbtypes.nim
@@ -21,7 +21,7 @@ func dbType*(T: typedesc[int16]): string = "SMALLINT"
 
 func dbType*(T: typedesc[int32]): string = "INTEGER"
 
-func dbType*(T: typedesc[int64 | Positive | int]): string = "BIGINT"
+func dbType*(T: typedesc[int64 | Positive | int | Natural]): string = "BIGINT"
 
 func dbType*(T: typedesc[float32]): string = "REAL"
 

--- a/src/norm/private/postgres/llexec.nim
+++ b/src/norm/private/postgres/llexec.nim
@@ -1,5 +1,5 @@
-import ndb/postgres {.all.}
-import ndb/wrappers/libpq
+import lowdb/postgres {.all.}
+import lowdb/wrappers/libpq
 
 proc execExpect(db: DbConn, query: SqlQuery, args: seq[DbValue],
                  expectedStatusType: ExecStatusType) =

--- a/src/norm/private/postgres/rowutils.nim
+++ b/src/norm/private/postgres/rowutils.nim
@@ -1,8 +1,8 @@
-## Procs to convert `Model <../../model.html#Model>`_ instances or ref object instances to ``ndb.postgres.Row`` instances and back.
+## Procs to convert `Model <../../model.html#Model>`_ instances or ref object instances to ``lowdb.postgres.Row`` instances and back.
 
 import std/options
 
-import ndb/postgres
+import lowdb/postgres
 
 import dbtypes
 import ../dot
@@ -21,7 +21,7 @@ func isEmptyColumn*(row: Row, index: int): bool =
 
 ## This does the actual heavy lifting for parsing
 proc fromRowPos[T: ref object](obj: var T, row: Row, pos: var Natural, skip: static bool = false) =
-  ##[ Convert ``ndb.sqlite.Row`` instance into ``ref object`` instance, from a given position.
+  ##[ Convert ``lowdb.sqlite.Row`` instance into ``ref object`` instance, from a given position.
 
   This is a helper proc to convert to ``ref object`` instances that have fields of the same type.
   ]##
@@ -45,7 +45,7 @@ proc fromRowPos[T: ref object](obj: var T, row: Row, pos: var Natural, skip: sta
 
       else:                                             ## If the field is a ``none ref object``,
         inc pos                                         ## don't bother trying to populate it at all.
-                                          
+
     else:
       when not skip:                                    ## If we're dealing with an "ordinary" field,
         dot(obj, fld) = row[pos].to(typeof(dummyVal))   ## just convert it.
@@ -53,19 +53,19 @@ proc fromRowPos[T: ref object](obj: var T, row: Row, pos: var Natural, skip: sta
 
       else:
         inc pos
-  
+
 
 proc fromRow*[T: ref object](obj: var T, row: Row) =
-  ##[ Populate ``ref object`` instance from ``ndb.postgres.Row`` instance.
+  ##[ Populate ``ref object`` instance from ``lowdb.postgres.Row`` instance.
 
-  Nested ``ref object`` fields are populated from the same ``ndb.postgres.Row`` instance.
+  Nested ``ref object`` fields are populated from the same ``lowdb.postgres.Row`` instance.
   ]##
 
   var pos: Natural = 0
   obj.fromRowPos(row, pos)
 
 proc toRow*[T: Model](obj: T, force = false): Row =
-  ##[ Convert `Model`_ instance into ``ndb.postgres.Row`` instance.
+  ##[ Convert `Model`_ instance into ``lowdb.postgres.Row`` instance.
 
   If ``force`` is ``true``, fields with `ro <../../pragmas.html#ro.t>`_ pragma are not skipped.
   ]##

--- a/src/norm/private/sqlite/dbtypes.nim
+++ b/src/norm/private/sqlite/dbtypes.nim
@@ -90,9 +90,9 @@ func to*(dbVal; T: typedesc[DbBlob]): T = dbVal.b
 
 proc to*(dbVal; T: typedesc[DateTime]): T = utc dbVal.f.fromUnixFloat()
 
-func to*[U](dbVal; T: typedesc[StringOfCap[U]]): T = dbVal.s.T
+func to*[T1](dbVal; T2: typedesc[StringOfCap[T1]]): T2 = dbVal.s.T2
 
-func to*[U](dbVal; T: typedesc[PaddedStringOfCap[U]]): T = dbVal.s.T
+func to*[T1](dbVal; T2: typedesc[PaddedStringOfCap[T1]]): T2 = dbVal.s.T2
 
 func to*(dbVal; T: typedesc[Model]): T =
   ## This is never called and exists only to please the compiler.

--- a/src/norm/private/sqlite/dbtypes.nim
+++ b/src/norm/private/sqlite/dbtypes.nim
@@ -1,15 +1,15 @@
-##[ Funcs to convert between Nim types and SQLite types and between Nim values and ``ndb.sqlite.DbValue``.
+##[ Funcs to convert between Nim types and SQLite types and between Nim values and ``lowdb.sqlite.DbValue``.
 
 To add support for ``YourType``, define three funcs:
 - ``dbType(T: typedesc[YourType]) -> string`` that returns SQL type for given ``YourType``
-- ``dbValue(YourType) -> DbValue`` that converts instances of ``YourType`` to ``ndb.sqlite.DbValue``
-- ``to(DbValue, T: typedesc[YourType]) -> T`` that converts ``ndb.sqlite.DbValue`` instances to ``YourType``.
+- ``dbValue(YourType) -> DbValue`` that converts instances of ``YourType`` to ``lowdb.sqlite.DbValue``
+- ``to(DbValue, T: typedesc[YourType]) -> T`` that converts ``lowdb.sqlite.DbValue`` instances to ``YourType``.
 ]##
 
 
 import std/[options, times]
 
-import ndb/sqlite
+import lowdb/sqlite
 
 import ../../model
 import ../../types

--- a/src/norm/private/sqlite/dbtypes.nim
+++ b/src/norm/private/sqlite/dbtypes.nim
@@ -46,9 +46,9 @@ func dbValue*(val: DateTime): DbValue = dbValue(val.toTime().toUnixFloat())
 
 func dbValue*[T: Model](val: T): DbValue = dbValue(val.id)
 
-func dbValue*[_](val: StringOfCap[_]): DbValue = dbValue(string(val))
+func dbValue*[T](val: StringOfCap[T]): DbValue = dbValue(string(val))
 
-func dbValue*[_](val: PaddedStringOfCap[_]): DbValue = dbValue(string(val))
+func dbValue*[T](val: PaddedStringOfCap[T]): DbValue = dbValue(string(val))
 
 func dbValue*(val: Option[bool]): DbValue =
   if val.isSome:
@@ -90,9 +90,9 @@ func to*(dbVal; T: typedesc[DbBlob]): T = dbVal.b
 
 proc to*(dbVal; T: typedesc[DateTime]): T = utc dbVal.f.fromUnixFloat()
 
-func to*[_](dbVal; T: typedesc[StringOfCap[_]]): T = dbVal.s.T
+func to*[U](dbVal; T: typedesc[StringOfCap[U]]): T = dbVal.s.T
 
-func to*[_](dbVal; T: typedesc[PaddedStringOfCap[_]]): T = dbVal.s.T
+func to*[U](dbVal; T: typedesc[PaddedStringOfCap[U]]): T = dbVal.s.T
 
 func to*(dbVal; T: typedesc[Model]): T =
   ## This is never called and exists only to please the compiler.

--- a/src/norm/private/sqlite/rowutils.nim
+++ b/src/norm/private/sqlite/rowutils.nim
@@ -1,8 +1,8 @@
-## Procs to convert `Model <../../model.html#Model>`_ instances or ref object instances to ``ndb.sqlite.Row`` instances and back.
+## Procs to convert `Model <../../model.html#Model>`_ instances or ref object instances to ``lowdb.sqlite.Row`` instances and back.
 
 import std/options
 
-import ndb/sqlite
+import lowdb/sqlite
 
 import dbtypes
 import ../dot
@@ -21,7 +21,7 @@ func isEmptyColumn*(row: Row, index: int): bool =
 
 ## This does the actual heavy lifting for parsing
 proc fromRowPos[T: ref object](obj: var T, row: Row, pos: var Natural, skip: static bool = false) =
-  ##[ Convert ``ndb.sqlite.Row`` instance into a ``ref object`` instance, from a given position.
+  ##[ Convert ``lowdb.sqlite.Row`` instance into a ``ref object`` instance, from a given position.
 
   This is a helper proc to convert to ``ref object`` instances that have fields of the same type.
   ]##
@@ -45,7 +45,7 @@ proc fromRowPos[T: ref object](obj: var T, row: Row, pos: var Natural, skip: sta
 
       else:                                             ## If the field is a ``none Model``,
         inc pos                                         ## don't bother trying to populate it at all.
-                                          
+
     else:
       when not skip:                                    ## If we're dealing with an "ordinary" field,
         dot(obj, fld) = row[pos].to(typeof(dummyVal))   ## just convert it.
@@ -53,18 +53,18 @@ proc fromRowPos[T: ref object](obj: var T, row: Row, pos: var Natural, skip: sta
 
       else:
         inc pos
-  
-proc fromRow*[T: ref object](obj: var T, row: Row) =
-  ##[ Populate ``ref object`` instance from ``ndb.sqlite.Row`` instance.
 
-  Nested ``ref object`` fields are populated from the same ``ndb.sqlite.Row`` instance.
+proc fromRow*[T: ref object](obj: var T, row: Row) =
+  ##[ Populate ``ref object`` instance from ``lowdb.sqlite.Row`` instance.
+
+  Nested ``ref object`` fields are populated from the same ``lowdb.sqlite.Row`` instance.
   ]##
 
   var pos: Natural = 0
   obj.fromRowPos(row, pos)
 
 proc toRow*[T: Model](obj: T, force = false): Row =
-  ##[ Convert `Model`_ instance into ``ndb.sqlite.Row`` instance.
+  ##[ Convert `Model`_ instance into ``lowdb.sqlite.Row`` instance.
 
   If ``force`` is ``true``, fields with `ro <../../pragmas.html#ro.t>`_ pragma are not skipped.
   ]##

--- a/src/norm/sqlite.nim
+++ b/src/norm/sqlite.nim
@@ -201,7 +201,7 @@ proc insert*[T: Model](dbConn; objs: var openArray[T], force = false, conflictPo
   for obj in objs.mitems:
     dbConn.insert(obj, force, conflictPolicy)
 
-proc select*[T: Model](dbConn; obj: var T, cond: string, params: varargs[DbValue, dbValue]) {.raises: {NotFoundError, ValueError, DbError, LoggingError, Exception}.} =
+proc select*[T: Model](dbConn; obj: var T, cond: string, params: varargs[DbValue, dbValue]) {.raises: {NotFoundError, ValueError, DbError, LoggingError}.} =
   ##[ Populate a `Model`_ instance and its `Model`_ fields from DB.
 
   ``cond`` is condition for ``WHERE`` clause but with extra features:
@@ -227,7 +227,7 @@ proc select*[T: Model](dbConn; obj: var T, cond: string, params: varargs[DbValue
 
   obj.fromRow(get row)
 
-proc select*[T: Model](dbConn; objs: var seq[T], cond: string, params: varargs[DbValue, dbValue]) {.raises: {ValueError, DbError, LoggingError, Exception}.} =
+proc select*[T: Model](dbConn; objs: var seq[T], cond: string, params: varargs[DbValue, dbValue]) {.raises: {ValueError, DbError, LoggingError}.} =
   ##[ Populate a sequence of `Model`_ instances from DB.
 
   ``objs`` must have at least one item.
@@ -265,7 +265,7 @@ proc selectAll*[T: Model](dbConn; objs: var seq[T]) =
 
   dbConn.select(objs, "1")
 
-proc rawSelect*[T: ref object](dbConn; qry: string, obj: var T, params: varargs[DbValue, dbValue]) {.raises: {ValueError, DbError, LoggingError, Exception}.} =
+proc rawSelect*[T: ref object](dbConn; qry: string, obj: var T, params: varargs[DbValue, dbValue]) {.raises: {ValueError, DbError, LoggingError}.} =
   ##[ Populate a ref object instance ``obj`` and its ref object fields from DB.
 
   ``qry`` is the raw sql query whose contents are to be parsed into obj.
@@ -279,7 +279,7 @@ proc rawSelect*[T: ref object](dbConn; qry: string, obj: var T, params: varargs[
 
   obj.fromRow(get row)
 
-proc rawSelect*[T: ref object](dbConn; qry: string, objs: var seq[T], params: varargs[DbValue, dbValue]) {.raises: {ValueError, DbError, LoggingError, Exception}.} =
+proc rawSelect*[T: ref object](dbConn; qry: string, objs: var seq[T], params: varargs[DbValue, dbValue]) {.raises: {ValueError, DbError, LoggingError}.} =
   ##[ Populate a sequence of ref object instances from DB.
 
   ``qry`` is the raw sql query whose contents are to be parsed into ``objs``.

--- a/src/norm/sqlite.nim
+++ b/src/norm/sqlite.nim
@@ -8,7 +8,7 @@ else:
   import std/macros
   export macros
 
-import ndb/sqlite
+import lowdb/sqlite
 export sqlite
 
 import private/sqlite/[dbtypes, rowutils]

--- a/src/norm/sqlite.nim
+++ b/src/norm/sqlite.nim
@@ -201,7 +201,7 @@ proc insert*[T: Model](dbConn; objs: var openArray[T], force = false, conflictPo
   for obj in objs.mitems:
     dbConn.insert(obj, force, conflictPolicy)
 
-proc select*[T: Model](dbConn; obj: var T, cond: string, params: varargs[DbValue, dbValue]) {.raises: {NotFoundError, ValueError, DbError, LoggingError}.} =
+proc select*[T: Model](dbConn; obj: var T, cond: string, params: varargs[DbValue, dbValue]) {.raises: {NotFoundError, ValueError, DbError, LoggingError, Exception}.} =
   ##[ Populate a `Model`_ instance and its `Model`_ fields from DB.
 
   ``cond`` is condition for ``WHERE`` clause but with extra features:
@@ -227,7 +227,7 @@ proc select*[T: Model](dbConn; obj: var T, cond: string, params: varargs[DbValue
 
   obj.fromRow(get row)
 
-proc select*[T: Model](dbConn; objs: var seq[T], cond: string, params: varargs[DbValue, dbValue]) {.raises: {ValueError, DbError, LoggingError}.} =
+proc select*[T: Model](dbConn; objs: var seq[T], cond: string, params: varargs[DbValue, dbValue]) {.raises: {ValueError, DbError, LoggingError, Exception}.} =
   ##[ Populate a sequence of `Model`_ instances from DB.
 
   ``objs`` must have at least one item.
@@ -265,7 +265,7 @@ proc selectAll*[T: Model](dbConn; objs: var seq[T]) =
 
   dbConn.select(objs, "1")
 
-proc rawSelect*[T: ref object](dbConn; qry: string, obj: var T, params: varargs[DbValue, dbValue]) {.raises: {ValueError, DbError, LoggingError}.} =
+proc rawSelect*[T: ref object](dbConn; qry: string, obj: var T, params: varargs[DbValue, dbValue]) {.raises: {ValueError, DbError, LoggingError, Exception}.} =
   ##[ Populate a ref object instance ``obj`` and its ref object fields from DB.
 
   ``qry`` is the raw sql query whose contents are to be parsed into obj.
@@ -279,7 +279,7 @@ proc rawSelect*[T: ref object](dbConn; qry: string, obj: var T, params: varargs[
 
   obj.fromRow(get row)
 
-proc rawSelect*[T: ref object](dbConn; qry: string, objs: var seq[T], params: varargs[DbValue, dbValue]) {.raises: {ValueError, DbError, LoggingError}.} =
+proc rawSelect*[T: ref object](dbConn; qry: string, objs: var seq[T], params: varargs[DbValue, dbValue]) {.raises: {ValueError, DbError, LoggingError, Exception}.} =
   ##[ Populate a sequence of ref object instances from DB.
 
   ``qry`` is the raw sql query whose contents are to be parsed into ``objs``.

--- a/src/norm/sqlite.nim
+++ b/src/norm/sqlite.nim
@@ -409,7 +409,7 @@ template transaction*(dbConn; body: untyped): untyped =
     log(commitQry)
     dbConn.exec(sql commitQry)
 
-  except:
+  except CatchableError:
     log(rollbackQry)
     dbConn.exec(sql rollbackQry)
 

--- a/src/norm/types.nim
+++ b/src/norm/types.nim
@@ -14,15 +14,15 @@ func newStringOfCap*[C: static[int]](val = ""): StringOfCap[C] =
 func newPaddedStringOfCap*[C: static[int]](val = ""): PaddedStringOfCap[C] =
   PaddedStringOfCap[C](val.alignLeft(C))
 
-func `==`*[_](x, y: StringOfCap[_]): bool =
+func `==`*[T](x, y: StringOfCap[T]): bool =
   string(x) == string(y)
 
-func `==`*[_](x, y: PaddedStringOfCap[_]): bool =
+func `==`*[T](x, y: PaddedStringOfCap[T]): bool =
   string(x) == string(y)
 
-func `$`*[_](s: StringOfCap[_]): string =
+func `$`*[T](s: StringOfCap[T]): string =
   string(s)
 
-func `$`*[_](s: PaddedStringOfCap[_]): string =
+func `$`*[T](s: PaddedStringOfCap[T]): string =
   string(s)
 

--- a/tests/postgres/tcount.nim
+++ b/tests/postgres/tcount.nim
@@ -1,4 +1,4 @@
-import std/[unittest, strutils, sugar, options]
+import std/[os, unittest, strutils, sugar, options]
 
 import norm/[model, postgres]
 
@@ -6,10 +6,10 @@ import ../models
 
 
 const
-  dbHost = "postgres"
-  dbUser = "postgres"
-  dbPassword = "postgres"
-  dbDatabase = "postgres"
+  dbHost = getEnv("PGHOST", "postgres")
+  dbUser = getEnv("PGUSER", "postgres")
+  dbPassword = getEnv("PGPASSWORD", "postgres")
+  dbDatabase = getEnv("PGDATABASE", "postgres")
 
 
 suite "Count rows":

--- a/tests/postgres/tdb.nim
+++ b/tests/postgres/tdb.nim
@@ -1,4 +1,4 @@
-import std/[unittest, os, strutils]
+import std/[os, unittest, os, strutils]
 
 import norm/[model, postgres]
 
@@ -6,10 +6,10 @@ import ../models
 
 
 const
-  dbHost = "postgres"
-  dbUser = "postgres"
-  dbPassword = "postgres"
-  dbDatabase = "postgres"
+  dbHost = getEnv("PGHOST", "postgres")
+  dbUser = getEnv("PGUSER", "postgres")
+  dbPassword = getEnv("PGPASSWORD", "postgres")
+  dbDatabase = getEnv("PGDATABASE", "postgres")
 
 
 suite "Database manipulation":

--- a/tests/postgres/tdbtypes.nim
+++ b/tests/postgres/tdbtypes.nim
@@ -1,4 +1,4 @@
-import std/[unittest, with, strutils, times, sugar]
+import std/[os, unittest, with, strutils, times, sugar]
 
 import norm/[model, postgres, types]
 
@@ -6,10 +6,10 @@ import ../models
 
 
 const
-  dbHost = "postgres"
-  dbUser = "postgres"
-  dbPassword = "postgres"
-  dbDatabase = "postgres"
+  dbHost = getEnv("PGHOST", "postgres")
+  dbUser = getEnv("PGUSER", "postgres")
+  dbPassword = getEnv("PGPASSWORD", "postgres")
+  dbDatabase = getEnv("PGDATABASE", "postgres")
 
 
 suite "Import dbTypes from norm/private/postgres/dbtypes":

--- a/tests/postgres/tenv.nim
+++ b/tests/postgres/tenv.nim
@@ -1,4 +1,4 @@
-import std/[unittest, os, strutils]
+import std/[os, unittest, os, strutils]
 
 import norm/[model, postgres]
 
@@ -6,10 +6,10 @@ import ../models
 
 
 const
-  dbHost = "postgres"
-  dbUser = "postgres"
-  dbPassword = "postgres"
-  dbDatabase = "postgres"
+  dbHost = getEnv("PGHOST", "postgres")
+  dbUser = getEnv("PGUSER", "postgres")
+  dbPassword = getEnv("PGPASSWORD", "postgres")
+  dbDatabase = getEnv("PGDATABASE", "postgres")
 
 
 suite "DB config from environment variables":

--- a/tests/postgres/texists.nim
+++ b/tests/postgres/texists.nim
@@ -1,4 +1,4 @@
-import std/[unittest, strutils, sugar, options]
+import std/[os, unittest, strutils, sugar, options]
 
 import norm/[model, postgres]
 
@@ -6,10 +6,10 @@ import ../models
 
 
 const
-  dbHost = "postgres"
-  dbUser = "postgres"
-  dbPassword = "postgres"
-  dbDatabase = "postgres"
+  dbHost = getEnv("PGHOST", "postgres")
+  dbUser = getEnv("PGUSER", "postgres")
+  dbPassword = getEnv("PGPASSWORD", "postgres")
+  dbDatabase = getEnv("PGDATABASE", "postgres")
 
 
 suite "Row existance check":

--- a/tests/postgres/tfkpragma.nim
+++ b/tests/postgres/tfkpragma.nim
@@ -1,4 +1,4 @@
-import std/[unittest, times, strutils]
+import std/[os, unittest, times, strutils]
 
 import norm/[model, postgres]
 
@@ -6,10 +6,10 @@ import ../models
 
 
 const
-  dbHost = "postgres"
-  dbUser = "postgres"
-  dbPassword = "postgres"
-  dbDatabase = "postgres"
+  dbHost = getEnv("PGHOST", "postgres")
+  dbUser = getEnv("PGUSER", "postgres")
+  dbPassword = getEnv("PGPASSWORD", "postgres")
+  dbDatabase = getEnv("PGDATABASE", "postgres")
 
 
 suite "``fk`` pragma":

--- a/tests/postgres/tfkpragma_selfref.nim
+++ b/tests/postgres/tfkpragma_selfref.nim
@@ -1,4 +1,4 @@
-import std/[unittest, strutils, options]
+import std/[os, unittest, strutils, options]
 
 import norm/[model, postgres]
 
@@ -6,10 +6,10 @@ import ../models
 
 
 const
-  dbHost = "postgres"
-  dbUser = "postgres"
-  dbPassword = "postgres"
-  dbDatabase = "postgres"
+  dbHost = getEnv("PGHOST", "postgres")
+  dbUser = getEnv("PGUSER", "postgres")
+  dbPassword = getEnv("PGPASSWORD", "postgres")
+  dbDatabase = getEnv("PGDATABASE", "postgres")
 
 
 suite "``fk`` pragma":

--- a/tests/postgres/tfkpragmanotint.nim
+++ b/tests/postgres/tfkpragmanotint.nim
@@ -2,16 +2,16 @@ discard """
   action: "reject"
 """
 
-import std/[unittest, os, times, strutils]
+import std/[os, unittest, os, times, strutils]
 
 import norm/[model, pragmas, sqlite]
 
 
 const
-  dbHost = "postgres"
-  dbUser = "postgres"
-  dbPassword = "postgres"
-  dbDatabase = "postgres"
+  dbHost = getEnv("PGHOST", "postgres")
+  dbUser = getEnv("PGUSER", "postgres")
+  dbPassword = getEnv("PGPASSWORD", "postgres")
+  dbDatabase = getEnv("PGDATABASE", "postgres")
 
 
 type

--- a/tests/postgres/tfkpragmanotmodel.nim
+++ b/tests/postgres/tfkpragmanotmodel.nim
@@ -2,16 +2,16 @@ discard """
   action: "reject"
 """
 
-import std/[unittest, os, times, strutils]
+import std/[os, unittest, os, times, strutils]
 
 import norm/[model, pragmas, sqlite]
 
 
 const
-  dbHost = "postgres"
-  dbUser = "postgres"
-  dbPassword = "postgres"
-  dbDatabase = "postgres"
+  dbHost = getEnv("PGHOST", "postgres")
+  dbUser = getEnv("PGUSER", "postgres")
+  dbPassword = getEnv("PGPASSWORD", "postgres")
+  dbDatabase = getEnv("PGDATABASE", "postgres")
 
 
 type

--- a/tests/postgres/tindexes.nim
+++ b/tests/postgres/tindexes.nim
@@ -1,4 +1,4 @@
-import std/[unittest, options, strutils]
+import std/[os, unittest, options, strutils]
 
 import norm/[model, postgres]
 
@@ -6,10 +6,10 @@ import ../models
 
 
 const
-  dbHost = "postgres"
-  dbUser = "postgres"
-  dbPassword = "postgres"
-  dbDatabase = "postgres"
+  dbHost = getEnv("PGHOST", "postgres")
+  dbUser = getEnv("PGUSER", "postgres")
+  dbPassword = getEnv("PGPASSWORD", "postgres")
+  dbDatabase = getEnv("PGDATABASE", "postgres")
 
 
 suite "Indexes":

--- a/tests/postgres/tnull.nim
+++ b/tests/postgres/tnull.nim
@@ -1,4 +1,4 @@
-import std/[unittest, options, strutils]
+import std/[os, unittest, options, strutils]
 
 import norm/[model, postgres]
 
@@ -6,10 +6,10 @@ import ../models
 
 
 const
-  dbHost = "postgres"
-  dbUser = "postgres"
-  dbPassword = "postgres"
-  dbDatabase = "postgres"
+  dbHost = getEnv("PGHOST", "postgres")
+  dbUser = getEnv("PGUSER", "postgres")
+  dbPassword = getEnv("PGPASSWORD", "postgres")
+  dbDatabase = getEnv("PGDATABASE", "postgres")
 
 
 suite "``NULL`` foreign keys":

--- a/tests/postgres/tpool.nim
+++ b/tests/postgres/tpool.nim
@@ -1,4 +1,4 @@
-import std/[unittest, os, strutils]
+import std/[os, unittest, os, strutils]
 
 import norm/[postgres, pool]
 
@@ -6,10 +6,10 @@ import ../models
 
 
 const
-  dbHost = "postgres"
-  dbUser = "postgres"
-  dbPassword = "postgres"
-  dbDatabase = "postgres"
+  dbHost = getEnv("PGHOST", "postgres")
+  dbUser = getEnv("PGUSER", "postgres")
+  dbPassword = getEnv("PGPASSWORD", "postgres")
+  dbDatabase = getEnv("PGDATABASE", "postgres")
 
 
 suite "Connection pool":
@@ -157,7 +157,7 @@ suite "Connection pool":
             while not exceptionRaised:
               sleep 100
         except PoolExhaustedError:
-          exceptionRaised = true 
+          exceptionRaised = true
 
     createThread(threads[0], getToy, 123.45)
     createThread(threads[1], getToy, 456.78)
@@ -208,8 +208,8 @@ suite "Connection pool":
 
 
   test """
-    Given 2 models with one entry depending on another and a pool with a custom connection-creation-proc, 
-    When the other entry gets deleted with a connection from the pool 
+    Given 2 models with one entry depending on another and a pool with a custom connection-creation-proc,
+    When the other entry gets deleted with a connection from the pool
     Then a DBError should occur due to FK checks
   """:
     var pool = newPool[DbConn](1, proc(): DbConn = open(dbHost, dbuser, dbPassword, dbDatabase))
@@ -225,5 +225,5 @@ suite "Connection pool":
 
       expect DBError:
         db.delete(toy)
-    
+
     close pool

--- a/tests/postgres/trawselect.nim
+++ b/tests/postgres/trawselect.nim
@@ -6,10 +6,10 @@ import ../models
 
 
 const
-  dbHost = "postgres"
-  dbUser = "postgres"
-  dbPassword = "postgres"
-  dbDatabase = "postgres"
+  dbHost = getEnv("PGHOST", "postgres")
+  dbUser = getEnv("PGUSER", "postgres")
+  dbPassword = getEnv("PGPASSWORD", "postgres")
+  dbDatabase = getEnv("PGDATABASE", "postgres")
 
 proc resetDb =
   let dbConn = open(dbHost, dbUser, dbPassword, "template1")

--- a/tests/postgres/trepeatfks.nim
+++ b/tests/postgres/trepeatfks.nim
@@ -1,4 +1,4 @@
-import std/[unittest, strutils]
+import std/[os, unittest, strutils]
 
 import norm/[model, postgres]
 
@@ -6,10 +6,10 @@ import ../models
 
 
 const
-  dbHost = "postgres"
-  dbUser = "postgres"
-  dbPassword = "postgres"
-  dbDatabase = "postgres"
+  dbHost = getEnv("PGHOST", "postgres")
+  dbUser = getEnv("PGUSER", "postgres")
+  dbPassword = getEnv("PGPASSWORD", "postgres")
+  dbDatabase = getEnv("PGDATABASE", "postgres")
 
 
 suite "Model with repeating foreign keys":

--- a/tests/postgres/tro.nim
+++ b/tests/postgres/tro.nim
@@ -1,4 +1,4 @@
-import std/[unittest, strutils, sugar, options]
+import std/[os, unittest, strutils, sugar, options]
 
 import norm/[model, postgres]
 
@@ -6,10 +6,10 @@ import ../models
 
 
 const
-  dbHost = "postgres"
-  dbUser = "postgres"
-  dbPassword = "postgres"
-  dbDatabase = "postgres"
+  dbHost = getEnv("PGHOST", "postgres")
+  dbUser = getEnv("PGUSER", "postgres")
+  dbPassword = getEnv("PGPASSWORD", "postgres")
+  dbDatabase = getEnv("PGDATABASE", "postgres")
 
 
 suite "Read-only models, non-mutating procs":

--- a/tests/postgres/tronocomp.nim
+++ b/tests/postgres/tronocomp.nim
@@ -4,7 +4,7 @@ discard """
   file: "model.nim"
 """
 
-import std/[unittest, strutils, sugar]
+import std/[os, unittest, strutils, sugar]
 
 import norm/[model, postgres]
 
@@ -12,10 +12,10 @@ import ../models
 
 
 const
-  dbHost = "postgres"
-  dbUser = "postgres"
-  dbPassword = "postgres"
-  dbDatabase = "postgres"
+  dbHost = getEnv("PGHOST", "postgres")
+  dbUser = getEnv("PGUSER", "postgres")
+  dbPassword = getEnv("PGPASSWORD", "postgres")
+  dbDatabase = getEnv("PGDATABASE", "postgres")
 
 
 suite "Read-only models, mutating procs":

--- a/tests/postgres/tronocomp2.nim
+++ b/tests/postgres/tronocomp2.nim
@@ -4,7 +4,7 @@ discard """
   file: "model.nim"
 """
 
-import std/[unittest, strutils, sugar]
+import std/[os, unittest, strutils, sugar]
 
 import norm/[model, postgres]
 
@@ -12,10 +12,10 @@ import ../models
 
 
 const
-  dbHost = "postgres"
-  dbUser = "postgres"
-  dbPassword = "postgres"
-  dbDatabase = "postgres"
+  dbHost = getEnv("PGHOST", "postgres")
+  dbUser = getEnv("PGUSER", "postgres")
+  dbPassword = getEnv("PGPASSWORD", "postgres")
+  dbDatabase = getEnv("PGDATABASE", "postgres")
 
 
 suite "Read-only models, mutating procs":

--- a/tests/postgres/trows.nim
+++ b/tests/postgres/trows.nim
@@ -1,4 +1,4 @@
-import std/[unittest, with, strutils, sugar, options]
+import std/[os, unittest, with, strutils, sugar, options]
 
 import norm/[model, postgres]
 
@@ -6,10 +6,10 @@ import ../models
 
 
 const
-  dbHost = "postgres"
-  dbUser = "postgres"
-  dbPassword = "postgres"
-  dbDatabase = "postgres"
+  dbHost = getEnv("PGHOST", "postgres")
+  dbUser = getEnv("PGUSER", "postgres")
+  dbPassword = getEnv("PGPASSWORD", "postgres")
+  dbDatabase = getEnv("PGDATABASE", "postgres")
 
 suite "Row CRUD":
   proc resetDb =
@@ -273,8 +273,8 @@ suite "Row CRUD":
     check dbConn.getRow(sql"""SELECT * FROM "Person" WHERE name = 'Alice'""").isNone
 
   test """
-    Given 2 models with one entry depending on another, 
-    When the other entry gets deleted 
+    Given 2 models with one entry depending on another,
+    When the other entry gets deleted
     Then a DBError should occur due to FK checks
   """:
     var toy = newToy(123.45)

--- a/tests/postgres/trowutils.nim
+++ b/tests/postgres/trowutils.nim
@@ -1,4 +1,4 @@
-import std/[unittest, options, times]
+import std/[os, unittest, options, times]
 
 import lowdb/postgres
 

--- a/tests/postgres/trowutils.nim
+++ b/tests/postgres/trowutils.nim
@@ -1,6 +1,6 @@
 import std/[unittest, options, times]
 
-import ndb/postgres
+import lowdb/postgres
 
 import norm/private/postgres/rowutils
 import norm/[model, pragmas]
@@ -8,7 +8,7 @@ import norm/[model, pragmas]
 import ../models
 
 
-suite "Converting between Model and ndb.postgres.Row":
+suite "Converting between Model and lowdb.postgres.Row":
   test "Built-in types":
     type
       Person = ref object of Model

--- a/tests/postgres/tsugar.nim
+++ b/tests/postgres/tsugar.nim
@@ -1,4 +1,4 @@
-import std/[unittest, with, strutils, sugar, sequtils]
+import std/[os, unittest, with, strutils, sugar, sequtils]
 
 import norm/[model, postgres]
 
@@ -6,10 +6,10 @@ import ../models
 
 
 const
-  dbHost = "postgres"
-  dbUser = "postgres"
-  dbPassword = "postgres"
-  dbDatabase = "postgres"
+  dbHost = getEnv("PGHOST", "postgres")
+  dbUser = getEnv("PGUSER", "postgres")
+  dbPassword = getEnv("PGPASSWORD", "postgres")
+  dbDatabase = getEnv("PGDATABASE", "postgres")
 
 
 suite "Fancy syntax":

--- a/tests/postgres/tsum.nim
+++ b/tests/postgres/tsum.nim
@@ -1,4 +1,4 @@
-import std/[unittest, strutils, sugar, options]
+import std/[os, unittest, strutils, sugar, options]
 
 import norm/[model, postgres]
 
@@ -6,10 +6,10 @@ import ../models
 
 
 const
-  dbHost = "postgres"
-  dbUser = "postgres"
-  dbPassword = "postgres"
-  dbDatabase = "postgres"
+  dbHost = getEnv("PGHOST", "postgres")
+  dbUser = getEnv("PGUSER", "postgres")
+  dbPassword = getEnv("PGPASSWORD", "postgres")
+  dbDatabase = getEnv("PGDATABASE", "postgres")
 
 
 suite "Row sum":

--- a/tests/postgres/ttables.nim
+++ b/tests/postgres/ttables.nim
@@ -1,4 +1,4 @@
-import std/[unittest, strutils]
+import std/[os, unittest, strutils]
 
 import norm/postgres
 
@@ -6,10 +6,10 @@ import ../models
 
 
 const
-  dbHost = "postgres"
-  dbUser = "postgres"
-  dbPassword = "postgres"
-  dbDatabase = "postgres"
+  dbHost = getEnv("PGHOST", "postgres")
+  dbUser = getEnv("PGUSER", "postgres")
+  dbPassword = getEnv("PGPASSWORD", "postgres")
+  dbDatabase = getEnv("PGDATABASE", "postgres")
 
 
 suite "Table creation":

--- a/tests/postgres/ttransactions.nim
+++ b/tests/postgres/ttransactions.nim
@@ -1,4 +1,4 @@
-import std/[unittest, strutils, sugar, options]
+import std/[os, unittest, strutils, sugar, options]
 
 import norm/[model, postgres]
 
@@ -6,10 +6,10 @@ import ../models
 
 
 const
-  dbHost = "postgres"
-  dbUser = "postgres"
-  dbPassword = "postgres"
-  dbDatabase = "postgres"
+  dbHost = getEnv("PGHOST", "postgres")
+  dbUser = getEnv("PGUSER", "postgres")
+  dbPassword = getEnv("PGPASSWORD", "postgres")
+  dbDatabase = getEnv("PGDATABASE", "postgres")
 
 
 suite "Transactions":

--- a/tests/postgres/ttriangle.nim
+++ b/tests/postgres/ttriangle.nim
@@ -1,4 +1,4 @@
-import std/[unittest, strutils, sugar]
+import std/[os, unittest, strutils, sugar]
 
 import norm/[model, postgres]
 
@@ -6,10 +6,10 @@ import ../models
 
 
 const
-  dbHost = "postgres"
-  dbUser = "postgres"
-  dbPassword = "postgres"
-  dbDatabase = "postgres"
+  dbHost = getEnv("PGHOST", "postgres")
+  dbUser = getEnv("PGUSER", "postgres")
+  dbPassword = getEnv("PGPASSWORD", "postgres")
+  dbDatabase = getEnv("PGDATABASE", "postgres")
 
 
 suite "Relation triangle":

--- a/tests/postgres/tunique.nim
+++ b/tests/postgres/tunique.nim
@@ -1,4 +1,4 @@
-import std/[unittest, strutils]
+import std/[os, unittest, strutils]
 
 import norm/[model, postgres]
 
@@ -6,10 +6,10 @@ import ../models
 
 
 const
-  dbHost = "postgres"
-  dbUser = "postgres"
-  dbPassword = "postgres"
-  dbDatabase = "postgres"
+  dbHost = getEnv("PGHOST", "postgres")
+  dbUser = getEnv("PGUSER", "postgres")
+  dbPassword = getEnv("PGPASSWORD", "postgres")
+  dbDatabase = getEnv("PGDATABASE", "postgres")
 
 
 suite "Unique fields":

--- a/tests/postgres/tuniquegroup.nim
+++ b/tests/postgres/tuniquegroup.nim
@@ -1,4 +1,4 @@
-import std/[unittest, options, strutils]
+import std/[os, unittest, options, strutils]
 
 import norm/[model, postgres]
 
@@ -6,10 +6,10 @@ import ../models
 
 
 const
-  dbHost = "postgres"
-  dbUser = "postgres"
-  dbPassword = "postgres"
-  dbDatabase = "postgres"
+  dbHost = getEnv("PGHOST", "postgres")
+  dbUser = getEnv("PGUSER", "postgres")
+  dbPassword = getEnv("PGPASSWORD", "postgres")
+  dbDatabase = getEnv("PGDATABASE", "postgres")
 
 
 suite "Unique constraint on multiple columns":

--- a/tests/sqlite/trowutils.nim
+++ b/tests/sqlite/trowutils.nim
@@ -1,6 +1,6 @@
 import std/[unittest, options, times]
 
-import ndb/sqlite
+import lowdb/sqlite
 
 import norm/private/sqlite/rowutils
 import norm/[model, pragmas]
@@ -11,7 +11,7 @@ import ../models
 const dtCmpThsld = initDuration(nanoseconds = 1000)
 
 
-suite "Converting between Model and ndb.sqlite.Row":
+suite "Converting between Model and lowdb.sqlite.Row":
   test "Built-in types":
     type
       Person = ref object of Model


### PR DESCRIPTION
closes #182 

Makes norm viable with nim devel:
- Swaps ndb for lowdb, which is useable with the current version of nim-devel
- Swaps out generics using `[_]` to `[T]` etc. due to breaking change introduced by https://github.com/nim-lang/Nim/pull/21192
See: https://github.com/nim-lang/Nim/issues/21435

Unrelated to that:
I introduced nimble tasks to run the tests because I got tired of looking up the exact command after the third time and I'd prefer just having a nimble task for everything related to a package :sweat_smile: 