### PR TITLE
Update lowdb version to 0.2.0 and add enum support

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,9 @@
 -   [t]—test suite improvement
 -   [d]—docs improvement
 
+## 2.7.1 (March XX, 2023)
+- [+] Enum Support
+
 ## 2.7.0 (February 27, 2023)
 
 - [+] Norm is not Nim 2.0 compatible (see [#182](https://github.com/moigagoo/norm/issues/182)).

--- a/norm.nimble
+++ b/norm.nimble
@@ -1,6 +1,6 @@
 # Package
 
-version       = "2.7.1"
+version       = "2.7.0"
 author        = "Constantine Molchanov"
 description   = "Nim ORM for SQLite and PostgreSQL."
 license       = "MIT"

--- a/norm.nimble
+++ b/norm.nimble
@@ -1,6 +1,6 @@
 # Package
 
-version       = "2.7.0"
+version       = "2.7.1"
 author        = "Constantine Molchanov"
 description   = "Nim ORM for SQLite and PostgreSQL."
 license       = "MIT"
@@ -10,7 +10,7 @@ skipDirs      = @["tests", "htmldocs"]
 
 # Dependencies
 
-requires "nim >= 1.4.0", "lowdb >= 0.1.1"
+requires "nim >= 1.4.0", "lowdb >= 0.2.0"
 
 
 task test, "Run tests":

--- a/src/norm/private/postgres/dbtypes.nim
+++ b/src/norm/private/postgres/dbtypes.nim
@@ -21,7 +21,7 @@ func dbType*(T: typedesc[int16]): string = "SMALLINT"
 
 func dbType*(T: typedesc[int32]): string = "INTEGER"
 
-func dbType*(T: typedesc[int64 | Positive | int | Natural]): string = "BIGINT"
+func dbType*(T: typedesc[int64 | Positive | int | Natural | enum]): string = "BIGINT"
 
 func dbType*(T: typedesc[float32]): string = "REAL"
 
@@ -61,7 +61,7 @@ func dbValue*[T](val: PaddedStringOfCap[T]): DbValue = dbValue(string(val))
 
 using dbVal: DbValue
 
-func to*(dbVal; T: typedesc[SomeInteger]): T = dbVal.i.T
+func to*(dbVal; T: typedesc[SomeInteger | enum]): T = dbVal.i.T
 
 func to*(dbVal; T: typedesc[SomeFloat]): T = dbVal.f.T
 

--- a/src/norm/private/postgres/dbtypes.nim
+++ b/src/norm/private/postgres/dbtypes.nim
@@ -19,9 +19,9 @@ import ../../types
 
 func dbType*(T: typedesc[int16]): string = "SMALLINT"
 
-func dbType*(T: typedesc[int32]): string = "INTEGER"
+func dbType*(T: typedesc[int32 | enum]): string = "INTEGER"
 
-func dbType*(T: typedesc[int64 | Positive | int | Natural | enum]): string = "BIGINT"
+func dbType*(T: typedesc[int64 | Positive | int | Natural]): string = "BIGINT"
 
 func dbType*(T: typedesc[float32]): string = "REAL"
 

--- a/src/norm/private/sqlite/dbtypes.nim
+++ b/src/norm/private/sqlite/dbtypes.nim
@@ -17,7 +17,7 @@ import ../../types
 
 # Funcs that return an SQLite type for a given Nim type:
 
-func dbType*(T: typedesc[SomeInteger]): string = "INTEGER"
+func dbType*(T: typedesc[SomeInteger | enum]): string = "INTEGER"
 
 func dbType*(T: typedesc[SomeFloat]): string = "FLOAT"
 
@@ -73,7 +73,7 @@ func dbValue*[T: Model](val: Option[T]): DbValue =
 
 using dbVal: DbValue
 
-func to*(dbVal; T: typedesc[SomeInteger]): T = dbVal.i.T
+func to*(dbVal; T: typedesc[SomeInteger | enum]): T = dbVal.i.T
 
 func to*(dbVal; T: typedesc[SomeFloat]): T = dbVal.f.T
 

--- a/tests/models.nim
+++ b/tests/models.nim
@@ -89,7 +89,7 @@ type
     email* {.uniqueIndex: "idx_student_emails".}: string
 
   CoinKind* = enum
-    ck1Cent, ck2Cents, ck5Cents, ck10Cents, ck20Cents, ck50Cents ck1Euro, ck2Euro
+    ck1Cent, ck2Cents, ck5Cents, ck10Cents, ck20Cents, ck50Cents, ck1Euro, ck2Euro
 
   Coin* = ref object of Model
     kind*: CoinKind

--- a/tests/models.nim
+++ b/tests/models.nim
@@ -88,6 +88,18 @@ type
     lastName* {.index: "idx_student_names".}: string
     email* {.uniqueIndex: "idx_student_emails".}: string
 
+  CoinKind* = enum
+    ck1Cent, ck2Cents, ck5Cents, ck10Cents, ck20Cents, ck50Cents ck1Euro, ck2Euro
+
+  Coin* = ref object of Model
+    kind*: CoinKind
+
+  CoinKind2* = enum
+    ckCent, ckPound
+
+  Coin2* = ref object of Model
+    kind*: CoinKind2
+
 
 func newToy*(price: float): Toy =
   Toy(price: price)
@@ -241,3 +253,14 @@ func newAccount*(status = 0, email = ""): Account =
 func newStudent*(firstName = "", lastName = "", email = ""): Student =
   Student(firstName: firstName, lastName: lastName, email: email)
 
+func newCoin*(coinKind: CoinKind = ck1Euro): Coin =
+  Coin(kind: coinKind)
+
+func `===`*(a, b: Coin): bool =
+  a.kind == b.kind
+
+func newCoin2*(coinKind: CoinKind2 = ckCent): Coin2 =
+  Coin2(kind: coinKind)
+
+func `===`*(a, b: Coin2): bool =
+  a.kind == b.kind


### PR DESCRIPTION
Lowdb is used for direct interaction with the database. This means easier enum support.
For supporting any new datatype, 3 procs are needed:
- to
- dbType
- dbValue

In the newest version it provides propper enum support, meaning no dbValue proc needs to be defined for it. Norm only needs to define "to" and "dbType".
These procs have now been added.

Further, tests were added to confirm that these procs can be overwritten by procs specific for a given enum.

Note:
I will be honest, I don't have the faintest clue where these types of tests "properly" belong. So I *think* they're correctly placed where they are (?).

Closes #166 