### PR TITLE
version bump lowdb

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,8 @@
 -   [t]—test suite improvement
 -   [d]—docs improvement
 
+## 2.8.1 (XX, XX, 2023)
+- [f] version bump lowdb to fix failed import of db_connector on nim 2.0.0
 
 ## 2.8.0 (April 5, 2023)
 

--- a/norm.nimble
+++ b/norm.nimble
@@ -10,7 +10,7 @@ skipDirs      = @["tests", "htmldocs"]
 
 # Dependencies
 
-requires "nim >= 1.4.0", "lowdb >= 0.2.0"
+requires "nim >= 1.4.0", "lowdb >= 0.2.1"
 
 taskRequires "setupBook", "nimib >= 0.3.8", "nimibook >= 0.3.1"
 taskRequires "benchmark", "benchy >= 0.0.1"


### PR DESCRIPTION
lowdb 0.2.1 provides a bugfix that otherwise
makes norm not work with 2.0.0 well.
The requires statement in lowdb 0.2.0 fails to import db_connector for nim 2.0.0. 0.2.1 fixes that.

Here the relevant commit on lowdb:
https://github.com/PhilippMDoerner/lowdb/commit/79874876914ba8f013b1ba845ffe06bab8a55c43