### PR TITLE
#196 Put taskrequires blocks behind a when-block

### DIFF
--- a/norm.nimble
+++ b/norm.nimble
@@ -15,7 +15,11 @@ requires "nim >= 1.4.0", "lowdb >= 0.2.1"
 when NimMajor >= 2:
   taskRequires "setupBook", "nimib >= 0.3.8", "nimibook >= 0.3.1"
   taskRequires "benchmark", "benchy >= 0.0.1"
-
+else:
+  # Task Dependencies
+  requires "nimib >= 0.3.8"
+  requires "nimibook >= 0.3.1"
+  requires "benchy >= 0.0.1"
 
 # Tasks
 

--- a/norm.nimble
+++ b/norm.nimble
@@ -12,8 +12,9 @@ skipDirs      = @["tests", "htmldocs"]
 
 requires "nim >= 1.4.0", "lowdb >= 0.2.1"
 
-taskRequires "setupBook", "nimib >= 0.3.8", "nimibook >= 0.3.1"
-taskRequires "benchmark", "benchy >= 0.0.1"
+when NimMajor >= 2:
+  taskRequires "setupBook", "nimib >= 0.3.8", "nimibook >= 0.3.1"
+  taskRequires "benchmark", "benchy >= 0.0.1"
 
 
 # Tasks


### PR DESCRIPTION
closes #196 

taskRequires was introduced in the nimble version
that comes with nim 2.0

Thus it can not be interpreted by nimble versions below that, i.e. used by nim 1.6.
Thus using this in the nimble file breaks backwards compatibility with any package using norm under nim 1.6.

This when-block makes the taskRequires blocks only visible for nim versions whose nimble version can deal with them.

@moigagoo I'd want you to be aware of that thus I'd like your approval of the PR.