### PR TITLE
Create Index If Not Exists

### DIFF
--- a/src/norm/sqlite.nim
+++ b/src/norm/sqlite.nim
@@ -141,14 +141,14 @@ proc createTables*[T: Model](dbConn; obj: T) =
   dbConn.exec(sql qry)
 
   for index, cols in indexes.pairs:
-    let qry = "CREATE INDEX $# ON $#($#);" % [index, T.table, cols.join(", ")]
+    let qry = "CREATE INDEX IF NOT EXISTS $# ON $#($#);" % [index, T.table, cols.join(", ")]
 
     log(qry)
 
     dbConn.exec(sql qry)
 
   for index, cols in uniqueIndexes.pairs:
-    let qry = "CREATE UNIQUE INDEX $# ON $#($#);" % [index, T.table, cols.join(", ")]
+    let qry = "CREATE UNIQUE INDEX IF NOT EXISTS $# ON $#($#);" % [index, T.table, cols.join(", ")]
 
     log(qry)
 


### PR DESCRIPTION
Added "IF NOT EXISTS" to index/uniqueIndex creation via pragmas. I did this so it's more in line with creating tables and to be able to run a migration regardless of whether the table is already built (before you would get an Exception when trying to build an existing database).