### PR TITLE
Add the ability to set custom schema name for Postres.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM nimlang/nim:1.6.10
+FROM nimlang/nim:1.6.18
 
 WORKDIR /usr/src/app
 

--- a/book/models.nim
+++ b/book/models.nim
@@ -90,6 +90,26 @@ This will result in this schema:
     CREATE TABLE IF NOT EXISTS "ThingTable"(attr TEXT NOT NULL, id INTEGER NOT NULL PRIMARY KEY)
 
 
+## Custom Table Name (PostgreSQL only)
+
+PostgreSQL schemas are named collections of tables (`read more in the docs <https://www.postgresql.org/docs/current/ddl-schemas.html>`__).
+
+To set a schema name for your model, use `schemaName` pragma:
+"""
+
+nbCode:
+  type
+    Dog* {.schemaName: "Animals", tableName: "Canine".} = ref object of Model
+      name: string
+
+nbText """
+This will result in this query being executed before creating the tables for the model:
+
+    CREATE SCHEMA IF NOT EXISTS "Animals"
+
+If the schema name is set, it's used in the model table name references, e.g. `"Animals"."Canine"`.
+
+
 ## Read-only Models
 
 To slim down DB queries when you don't need to fetch the full model, use read-only models.

--- a/book/models.nim
+++ b/book/models.nim
@@ -69,7 +69,7 @@ Norm will generate the following table schema:
 
     CREATE TABLE IF NOT EXISTS "User"(email TEXT NOT NULL, name TEXT NOT NULL UNIQUE, id INTEGER NOT NULL PRIMARY KEY)
 
-To define unique combination or columns, add `{.uniqueGroup.}` pragma to each field in the group.
+To define unique combination or columns, add `uniqueGroup` pragma to each field in the group.
 
 
 ## Custom Table Name

--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,12 @@
 -   [t]—test suite improvement
 -   [d]—docs improvement
 
+
+## 2.8.2 (WIP)
+
+- [+] PostgreSQL: Add the ability to set custom schema name for models (see [#202](https://github.com/moigagoo/norm/pull/202)).
+
+
 ## 2.8.1 (August 11, 2023)
 
 - [f] version bump lowdb to fix failed import of db_connector on nim 2.0.0

--- a/src/norm/model.nim
+++ b/src/norm/model.nim
@@ -36,13 +36,33 @@ func model*[T](val: T): Option[Model] =
 
   none Model
 
+func schema*(T: typedesc[Model]): Option[string] =
+  ##[ Get schema name for `Model <#Model>`_, which is the value of `schemaName <pragmas.html#schemaName.t,string>`_ pragma.
+
+  `none(string)` means default schema.
+
+  Ignored in SQLite.
+  ]##
+
+  when T.hasCustomPragma(schemaName):
+    some '"' & T.getCustomPragmaVal(schemaName) & '"'
+  else:
+    none(string)
+
 func table*(T: typedesc[Model]): string =
-  ## Get table name for `Model <#Model>`_, which is the type name in single quotes.
+  ##[ Get table name for `Model <#Model>`_,
+  which is the value of `tableName <pragmas.html#tableName.t,string>`_ pragma or the type name in double quotes.
+
+  If `schemaName`_ is set, it's prepended to the table name.
+  ]##
+
+  if T.schema.isSome:
+    result &= get(T.schema) & '.'
 
   when T.hasCustomPragma(tableName):
-    '"' & T.getCustomPragmaVal(tableName) & '"'
+    result &= '"' & T.getCustomPragmaVal(tableName) & '"'
   else:
-    '"' & $T & '"'
+    result &= '"' & $T & '"'
 
 func col*(T: typedesc[Model], fld: string): string =
   ## Get column name for a `Model`_ field, which is just the field name.

--- a/src/norm/pragmas.nim
+++ b/src/norm/pragmas.nim
@@ -34,6 +34,9 @@ template fk*(val: typed) {.pragma.}
 template onDelete*(val: string) {.pragma.}
   ## Add ``ON DELETE {val}`` constraint to the column.
 
+template schemaName*(val: string) {.pragma.}
+  ## Custom schema name for a model.
+
 template tableName*(val: string) {.pragma.}
   ## Custom table name for a model.
 

--- a/src/norm/private/postgres/dbtypes.nim
+++ b/src/norm/private/postgres/dbtypes.nim
@@ -44,6 +44,8 @@ func dbType*[T](_: typedesc[Option[T]]): string = dbType T
 
 # Converter funcs from Nim values to ``DbValue``:
 
+func dbValue*(val: typeof(nil)): DbValue = DbValue(kind: dvkNull)
+
 func dbValue*[T: Model](val: T): DbValue = dbValue(val.id)
 
 func dbValue*[T: Model](val: Option[T]): DbValue =

--- a/src/norm/private/sqlite/dbtypes.nim
+++ b/src/norm/private/sqlite/dbtypes.nim
@@ -40,6 +40,8 @@ func dbType*[T](_: typedesc[Option[T]]): string = dbType T
 
 # Converter funcs from Nim values to ``DbValue``:
 
+func dbValue*(val: typeof(nil)): DbValue = DbValue(kind: dvkNull)
+
 func dbValue*(val: bool): DbValue = dbValue(if val: 1 else: 0)
 
 func dbValue*(val: DateTime): DbValue = dbValue(val.toTime().toUnixFloat())

--- a/src/norm/sqlite.nim
+++ b/src/norm/sqlite.nim
@@ -69,6 +69,11 @@ proc dropDb* =
 
 # Table manipulation
 
+proc createSchema*[T: Model](dbConn; obj: T) =
+  ## Dummy proc for API consistency.
+
+  discard
+
 proc createTables*[T: Model](dbConn; obj: T) =
   ## Create tables for `Model <model.html#Model>`_ and its `Model`_ fields.
 

--- a/tests/common/tmodel.nim
+++ b/tests/common/tmodel.nim
@@ -9,6 +9,7 @@ suite "Getting table and columns from Model":
   test "Table":
     check Person.table == """"Person""""
     check Table.table == """"FurnitureTable""""
+    check FurnitureTable.table == """"Furniture"."FurnitureTable""""
 
   test "Columns":
     let

--- a/tests/models.nim
+++ b/tests/models.nim
@@ -76,6 +76,9 @@ type
   Table* {.tableName: "FurnitureTable".} = ref object of Model
     legCount*: Positive
 
+  FurnitureTable* {.schemaName: "Furniture", tableName: "FurnitureTable".} = ref object of Model
+    legCount*: Positive
+
   SelfRef* = ref object of Model
     parent* {.fk: SelfRef.}: Option[int64]
 
@@ -236,6 +239,9 @@ func `===`*(a, b: String): bool =
 
 func newTable*(legCount: Positive = 4): Table =
   Table(legCount: legCount)
+
+func newFurnitureTable*(legCount: Positive = 4): FurnitureTable =
+  FurnitureTable(legCount: legCount)
 
 func newPetSpecies*: PetSpecies = PetSpecies(species: "")
 

--- a/tests/postgres/ttables.nim
+++ b/tests/postgres/ttables.nim
@@ -59,6 +59,23 @@ suite "Table creation":
       @[?"legcount", ?dftDbInt]
     ]
 
+  test "Create table with custom schema":
+    let furnitureTable = newFurnitureTable()
+
+    dbConn.createTables(furnitureTable)
+
+    let
+      qry = sql """SELECT column_name::text, data_type::text
+        FROM information_schema.columns
+        WHERE table_schema = $1 AND table_name = $2
+        ORDER BY column_name"""
+      dftDbInt = if high(int) == high(int64): "bigint" else: "integer"
+
+    check dbConn.getAllRows(qry, "Furniture", "FurnitureTable") == @[
+      @[?"id", ?"bigint"],
+      @[?"legcount", ?dftDbInt]
+    ]
+
   test "Create tables":
     let
       toy = newToy(123.45)


### PR DESCRIPTION
1. Add new pragma "schemaName".
2. If it's set, the schema is created before table creation using new "postgres.createSchema" proc.
