### PR TITLE
Make creating indices idempotent

### DIFF
--- a/src/norm/postgres.nim
+++ b/src/norm/postgres.nim
@@ -159,14 +159,14 @@ proc createTables*[T: Model](dbConn; obj: T) =
   dbConn.exec(sql qry)
 
   for index, cols in indexes.pairs:
-    let qry = "CREATE INDEX $# ON $#($#);" % [index, T.table, cols.join(", ")]
+    let qry = "CREATE INDEX IF NOT EXISTS $# ON $#($#);" % [index, T.table, cols.join(", ")]
 
     log(qry)
 
     dbConn.exec(sql qry)
 
   for index, cols in uniqueIndexes.pairs:
-    let qry = "CREATE UNIQUE INDEX $# ON $#($#);" % [index, T.table, cols.join(", ")]
+    let qry = "CREATE UNIQUE INDEX IF NOT EXISTS $# ON $#($#);" % [index, T.table, cols.join(", ")]
 
     log(qry)
 

--- a/src/norm/sqlite.nim
+++ b/src/norm/sqlite.nim
@@ -146,14 +146,14 @@ proc createTables*[T: Model](dbConn; obj: T) =
   dbConn.exec(sql qry)
 
   for index, cols in indexes.pairs:
-    let qry = "CREATE INDEX $# ON $#($#);" % [index, T.table, cols.join(", ")]
+    let qry = "CREATE INDEX IF NOT EXISTS $# ON $#($#);" % [index, T.table, cols.join(", ")]
 
     log(qry)
 
     dbConn.exec(sql qry)
 
   for index, cols in uniqueIndexes.pairs:
-    let qry = "CREATE UNIQUE INDEX $# ON $#($#);" % [index, T.table, cols.join(", ")]
+    let qry = "CREATE UNIQUE INDEX IF NOT EXISTS $# ON $#($#);" % [index, T.table, cols.join(", ")]
 
     log(qry)
 


### PR DESCRIPTION
This fixes the `DbError` that occurs when Norm attempts to create an index that already exists in the database.  
Using indices was impossible for some database schemas as the recursive nature of `createTables` can lead to the same Model being processed multiple times. This is no problem for relations that already exist but it causes an uncircumventable `DbError` for already existing indices. 